### PR TITLE
Check prod 1 implementation for similar issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,10 +22,16 @@ async function loadProducts() {
 
 // Wishlist-Logik (bereits initialisiert oben)
 
+function getWishlist() {
+  return JSON.parse(localStorage.getItem('wishlist')) || [];
+}
+
+function setWishlist(wishlist) {
+  localStorage.setItem('wishlist', JSON.stringify(wishlist));
+}
+
 function isInWishlist(productId) {
-  // Lade immer die aktuelle Wunschliste aus dem localStorage
-  const currentWishlist = JSON.parse(localStorage.getItem('wishlist')) || [];
-  return currentWishlist.some(item => Number(item.id) === Number(productId));
+  return getWishlist().some(item => Number(item.id) === Number(productId));
 }
 
 function toggleWishlist(productId) {
@@ -36,26 +42,43 @@ function toggleWishlist(productId) {
       alert('Produkt konnte nicht zur Wunschliste hinzugefügt werden.');
       return;
     }
-    wishlist = JSON.parse(localStorage.getItem('wishlist')) || [];
+    
+    let wishlist = getWishlist();
+    
     if (isInWishlist(productId)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(productId));
       showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
     } else {
-      // Nur vollständige Produktobjekte speichern
-      const fullProduct = {
+      wishlist.push({
         id: product.id,
-        name: product.name || 'Produkt',
-        price: typeof product.price === 'number' ? product.price : 0,
-        category: product.category || '',
-        image: product.image || 'waren/ware.png',
-        description: product.description || ''
-      };
-      wishlist.push(fullProduct);
+        name: product.name,
+        price: product.price,
+        image: product.image,
+        description: product.description
+      });
       showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
     }
-    localStorage.setItem('wishlist', JSON.stringify(wishlist));
-    renderProducts(products); // Herz-Status aktualisieren
+    
+    setWishlist(wishlist);
+    
+    // Update only the specific wishlist button instead of re-rendering everything
+    updateWishlistButtonState(productId);
   });
+}
+
+// Update wishlist button state without re-rendering
+function updateWishlistButtonState(productId) {
+  const wishlistBtn = document.querySelector(`.wishlist-btn[data-product-id="${productId}"]`);
+  if (wishlistBtn) {
+    const icon = wishlistBtn.querySelector('i');
+    if (icon) {
+      if (isInWishlist(productId)) {
+        icon.className = 'bi bi-heart-fill';
+      } else {
+        icon.className = 'bi bi-heart';
+      }
+    }
+  }
 }
 
 // Produktgrid rendern (mit Herz oben rechts)


### PR DESCRIPTION
Refactor wishlist functionality to match `produkt-1.html` and prevent event listener loss on buttons.

The previous implementation re-rendered the entire product grid after a wishlist action, which caused event listeners on the wishlist buttons to be lost. By adopting the `getWishlist`/`setWishlist` helpers and updating only the specific button's state, the functionality now works reliably.

---
<a href="https://cursor.com/background-agent?bcId=bc-78e6085b-ac64-4ae8-ae96-85f90e37f5ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78e6085b-ac64-4ae8-ae96-85f90e37f5ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

## Summary by Sourcery

Use helper functions for wishlist storage and update only the targeted wishlist button state on toggle instead of re-rendering the entire product grid to maintain event listeners

Bug Fixes:
- Prevent wishlist button event listeners from being lost by avoiding full grid re-render

Enhancements:
- Extract localStorage operations into getWishlist and setWishlist helpers
- Simplify stored wishlist item structure to only necessary fields
- Introduce updateWishlistButtonState to toggle button icons dynamically