### PR TITLE
Center help page on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -763,6 +763,22 @@ footer a:hover {
   box-shadow: 0 8px 32px rgba(0,122,255,0.4);
 }
 
+/* Mobile-Hilfe-Button Anpassungen */
+@media (max-width: 768px) {
+  #hilfeButton {
+    bottom: 20px;
+    right: 20px;
+    width: 60px;
+    height: 60px;
+    font-size: 2.2rem;
+    box-shadow: 0 6px 20px rgba(0,122,255,0.25);
+  }
+  
+  #hilfeButton:hover {
+    transform: scale(1.05);
+  }
+}
+
 /* Moderne Hilfe-Panel */
 .hilfe-panel {
   position: fixed;
@@ -779,6 +795,23 @@ footer a:hover {
   transition: all 0.3s ease;
   z-index: 999;
   overflow: hidden;
+}
+
+/* Mobile-zentriertes Hilfe-Panel */
+@media (max-width: 768px) {
+  .hilfe-panel {
+    bottom: 50%;
+    right: 50%;
+    transform: translate(50%, 50%) translateY(20px);
+    width: 90vw;
+    max-width: 320px;
+    max-height: 80vh;
+    overflow-y: auto;
+  }
+  
+  .hilfe-panel.offen {
+    transform: translate(50%, 50%) translateY(0);
+  }
 }
 
 .hilfe-panel.offen {
@@ -841,6 +874,38 @@ footer a:hover {
     color: white;
     border-color: var(--primary-color);
     transform: translateX(4px);
+}
+
+/* Mobile-Hilfe-Themen Anpassungen */
+@media (max-width: 768px) {
+  .hilfe-themen-modern {
+    padding: 20px;
+  }
+  
+  .hilfe-thema-btn {
+    padding: 16px 20px;
+    margin-bottom: 12px;
+    font-size: 1.1rem;
+    border-radius: 12px;
+    min-height: 56px;
+    display: flex;
+    align-items: center;
+  }
+  
+  .hilfe-thema-btn:hover {
+    transform: translateX(2px);
+  }
+  
+  .hilfe-panel-header {
+    padding: 24px 20px;
+    font-size: 1.2rem;
+  }
+  
+  #hilfePanelClose {
+    width: 32px;
+    height: 32px;
+    font-size: 1.8rem;
+  }
 }
 
 /* Animationen */


### PR DESCRIPTION
Implement mobile-specific styling for the help page to center the panel and improve touch-friendliness.

---
<a href="https://cursor.com/background-agent?bcId=bc-72579b5a-1a3f-4e00-873c-e3d5f4d3cf38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72579b5a-1a3f-4e00-873c-e3d5f4d3cf38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>