### PR TITLE
Fix shopping cart dropdown button

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -637,7 +637,19 @@ function changeQuantity(productId, change) {
         if (typeof updateCartCounter === 'function') {
             updateCartCounter();
         }
-        updateCartPage();
+        
+        // Check if we're on the cart page or main page
+        if (window.location.pathname.includes('cart.html')) {
+            // If on cart page, update the cart page
+            if (typeof updateCartPage === 'function') {
+                updateCartPage();
+            }
+        } else {
+            // If on main page, update the dropdown
+            if (typeof renderCartDropdown === 'function') {
+                renderCartDropdown();
+            }
+        }
     }
 }
 
@@ -648,13 +660,36 @@ function removeFromCart(productId) {
     if (typeof updateCartCounter === 'function') {
         updateCartCounter();
     }
-    window.location.href = 'cart.html';
+    
+    // Check if we're on the cart page or main page
+    if (window.location.pathname.includes('cart.html')) {
+        // If on cart page, redirect to cart.html
+        window.location.href = 'cart.html';
+    } else {
+        // If on main page, just update the dropdown
+        if (typeof renderCartDropdown === 'function') {
+            renderCartDropdown();
+        }
+    }
 }
 
 function clearCart() {
     localStorage.removeItem('cart');
     cartItems = [];
-    updateCartPage();
+    
+    // Check if we're on the cart page or main page
+    if (window.location.pathname.includes('cart.html')) {
+        // If on cart page, update the cart page
+        if (typeof updateCartPage === 'function') {
+            updateCartPage();
+        }
+    } else {
+        // If on main page, update the dropdown
+        if (typeof renderCartDropdown === 'function') {
+            renderCartDropdown();
+        }
+    }
+    
     if (typeof updateCartCounter === 'function') {
         updateCartCounter();
     }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes cart dropdown buttons by conditionally updating the dropdown or redirecting based on the current page.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `removeFromCart`, `clearCart`, and `changeQuantity` functions in `cart.js` were overriding the versions in `app.js` due to script loading order. This caused the dropdown's remove button to redirect to `cart.html` instead of just updating the dropdown. The fix introduces a check for `window.location.pathname` to apply the correct behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4e623cb-30e7-4327-ad98-a48372f7014b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4e623cb-30e7-4327-ad98-a48372f7014b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>