### PR TITLE
Make wishlist button function like top one

### DIFF
--- a/produkte/produkt-1.html
+++ b/produkte/produkt-1.html
@@ -360,6 +360,11 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Produkt von der Wunschliste entfernt');
+      }
     } else {
       wishlist.push({
         id: product.id,
@@ -368,6 +373,11 @@
         image: product.image,
         description: product.description
       });
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Produkt zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();

--- a/produkte/produkt-10.html
+++ b/produkte/produkt-10.html
@@ -372,8 +372,12 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      showNotification('Von der Wunschliste entfernt', 'info');
-            } else {
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
+    } else {
       wishlist.push({
         id: product.id,
         name: product.name,
@@ -381,7 +385,11 @@
         image: product.image,
         description: product.description
       });
-      showNotification('Zur Wunschliste hinzugefügt');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();

--- a/produkte/produkt-11.html
+++ b/produkte/produkt-11.html
@@ -266,8 +266,12 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      showNotification('Von der Wunschliste entfernt', 'info');
-            } else {
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
+    } else {
       wishlist.push({
         id: product.id,
         name: product.name,
@@ -275,7 +279,11 @@
         image: product.image,
         description: product.description
       });
-      showNotification('Zur Wunschliste hinzugefügt');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();

--- a/produkte/produkt-12.html
+++ b/produkte/produkt-12.html
@@ -266,8 +266,12 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      showNotification('Von der Wunschliste entfernt', 'info');
-            } else {
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
+    } else {
       wishlist.push({
         id: product.id,
         name: product.name,
@@ -275,7 +279,11 @@
         image: product.image,
         description: product.description
       });
-      showNotification('Zur Wunschliste hinzugefügt');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();

--- a/produkte/produkt-2.html
+++ b/produkte/produkt-2.html
@@ -346,7 +346,11 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      showNotification('Von der Wunschliste entfernt', 'info');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
     } else {
       wishlist.push({
         id: product.id,
@@ -355,7 +359,11 @@
         image: product.image,
         description: product.description
       });
-      showNotification('Zur Wunschliste hinzugefügt');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();

--- a/produkte/produkt-3.html
+++ b/produkte/produkt-3.html
@@ -346,8 +346,12 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      showNotification('Von der Wunschliste entfernt', 'info');
-            } else {
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
+    } else {
       wishlist.push({
         id: product.id,
         name: product.name,
@@ -355,7 +359,11 @@
         image: product.image,
         description: product.description
       });
-      showNotification('Zur Wunschliste hinzugefügt');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();

--- a/produkte/produkt-4.html
+++ b/produkte/produkt-4.html
@@ -349,8 +349,12 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      showNotification('Von der Wunschliste entfernt', 'info');
-            } else {
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
+    } else {
       wishlist.push({
         id: product.id,
         name: product.name,
@@ -358,7 +362,11 @@
         image: product.image,
         description: product.description
       });
-      ('Zur Wunschliste hinzugefügt');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();

--- a/produkte/produkt-5.html
+++ b/produkte/produkt-5.html
@@ -346,8 +346,12 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      showNotification('Von der Wunschliste entfernt', 'info');
-            } else {
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
+    } else {
       wishlist.push({
         id: product.id,
         name: product.name,
@@ -355,7 +359,11 @@
         image: product.image,
         description: product.description
       });
-      showNotification('Zur Wunschliste hinzugefügt');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();

--- a/produkte/produkt-6.html
+++ b/produkte/produkt-6.html
@@ -349,8 +349,12 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      showNotification('Von der Wunschliste entfernt', 'info');
-            } else {
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
+    } else {
       wishlist.push({
         id: product.id,
         name: product.name,
@@ -358,7 +362,11 @@
         image: product.image,
         description: product.description
       });
-      showNotification('Zur Wunschliste hinzugefügt');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();

--- a/produkte/produkt-7.html
+++ b/produkte/produkt-7.html
@@ -372,8 +372,12 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      showNotification('Von der Wunschliste entfernt', 'info');
-            } else {
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
+    } else {
       wishlist.push({
         id: product.id,
         name: product.name,
@@ -381,7 +385,11 @@
         image: product.image,
         description: product.description
       });
-      showNotification('Zur Wunschliste hinzugefügt');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();

--- a/produkte/produkt-8.html
+++ b/produkte/produkt-8.html
@@ -376,8 +376,12 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      showNotification('Von der Wunschliste entfernt', 'info');
-            } else {
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
+    } else {
       wishlist.push({
         id: product.id,
         name: product.name,
@@ -385,7 +389,11 @@
         image: product.image,
         description: product.description
       });
-      showNotification('Zur Wunschliste hinzugefügt');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();

--- a/produkte/produkt-9.html
+++ b/produkte/produkt-9.html
@@ -372,8 +372,12 @@
     let wishlist = getWishlist();
     if (isInWishlist(product.id)) {
       wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      showNotification('Von der Wunschliste entfernt', 'info');
-            } else {
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
+    } else {
       wishlist.push({
         id: product.id,
         name: product.name,
@@ -381,7 +385,11 @@
         image: product.image,
         description: product.description
       });
-      showNotification('Zur Wunschliste hinzugefügt');
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
     }
     setWishlist(wishlist);
     updateWishlistButton();


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Unify "Zur Wunschliste" button functionality on product pages to use the main app's notification system.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b7c0bad-5318-4112-a2cf-d33bcf14c8ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6b7c0bad-5318-4112-a2cf-d33bcf14c8ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

## Summary by Sourcery

Unify wishlist button behavior across product pages to leverage the main app's notification system by using showAlert when available and falling back to showNotification.

Enhancements:
- Replace direct showNotification calls for adding/removing wishlist items with a conditional showAlert invocation targeting wishlist.html, falling back to showNotification if showAlert is undefined
- Standardize notification messages for wishlist actions across all product pages