### PR TITLE
Change help options colors to orange

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,6 +420,9 @@ if (searchInput && mobileSearchBtn) {
     hilfeThemen.style.display = 'flex';
     hilfePanelHeader.style.display = 'flex'; // Zeige lila Header wieder
     chatbotMessages.innerHTML = '';
+    
+    // Deaktiviere orange Support-Farben
+    deactivateOrangeSupport();
   }
   
   function addWelcomeMessage() {
@@ -460,10 +463,10 @@ if (searchInput && mobileSearchBtn) {
     const botMessage = `
       <div class="chatbot-message bot-message">
         <div class="message-content">
-          <div class="bot-avatar">
+          <div class="bot-avatar orange-support">
             <i class="bi bi-headset"></i>
           </div>
-          <div class="message-text">
+          <div class="message-text orange-support">
             <p>${response.answer}</p>
           </div>
         </div>
@@ -545,12 +548,75 @@ if (searchInput && mobileSearchBtn) {
   function handleTopicClick(topic) {
     const response = topicResponses[topic];
     if (response) {
+      // Aktiviere orange Support-Farben
+      activateOrangeSupport();
+      
       addUserMessage(response.question);
       setTimeout(() => {
         addBotMessage(response);
         chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
       }, 500);
     }
+  }
+  
+  function activateOrangeSupport() {
+    // Füge orange Klassen zu den relevanten Elementen hinzu
+    const hilfePanelHeader = document.getElementById('hilfePanelHeader');
+    const chatbotHeader = document.querySelector('.chatbot-header');
+    const messageTexts = document.querySelectorAll('.message-text');
+    const botAvatars = document.querySelectorAll('.bot-avatar');
+    const quickTopicBtns = document.querySelectorAll('.quick-topic-btn');
+    
+    if (hilfePanelHeader) {
+      hilfePanelHeader.classList.add('orange-support');
+    }
+    if (chatbotHeader) {
+      chatbotHeader.classList.add('orange-support');
+    }
+    
+    // Füge orange Klassen zu allen Nachrichten und Avataren hinzu
+    messageTexts.forEach(text => {
+      if (!text.closest('.user-message')) { // Nur Bot-Nachrichten
+        text.classList.add('orange-support');
+      }
+    });
+    
+    botAvatars.forEach(avatar => {
+      avatar.classList.add('orange-support');
+    });
+    
+    // Füge orange Klassen zu Quick Topic Buttons hinzu
+    quickTopicBtns.forEach(btn => {
+      btn.classList.add('orange-support');
+    });
+  }
+  
+  function deactivateOrangeSupport() {
+    // Entferne orange Klassen von den relevanten Elementen
+    const hilfePanelHeader = document.getElementById('hilfePanelHeader');
+    const chatbotHeader = document.querySelector('.chatbot-header');
+    const messageTexts = document.querySelectorAll('.message-text');
+    const botAvatars = document.querySelectorAll('.bot-avatar');
+    const quickTopicBtns = document.querySelectorAll('.quick-topic-btn');
+    
+    if (hilfePanelHeader) {
+      hilfePanelHeader.classList.remove('orange-support');
+    }
+    if (chatbotHeader) {
+      chatbotHeader.classList.remove('orange-support');
+    }
+    
+    messageTexts.forEach(text => {
+      text.classList.remove('orange-support');
+    });
+    
+    botAvatars.forEach(avatar => {
+      avatar.classList.remove('orange-support');
+    });
+    
+    quickTopicBtns.forEach(btn => {
+      btn.classList.remove('orange-support');
+    });
   }
   
   // Event Listeners
@@ -583,6 +649,8 @@ if (searchInput && mobileSearchBtn) {
   document.addEventListener('click', (e) => {
     if (e.target.classList.contains('quick-topic-btn')) {
       const topic = e.target.getAttribute('data-topic');
+      // Aktiviere orange Support-Farben für Quick Topic Buttons
+      activateOrangeSupport();
       handleTopicClick(topic);
     }
   });

--- a/styles.css
+++ b/styles.css
@@ -39,6 +39,12 @@ html, body {
   --border-radius: 16px;
   --border-radius-small: 8px;
   --border-radius-large: 24px;
+  
+  /* Orange Farben für Support-Optionen */
+  --orange-primary: #ff8c00;
+  --orange-gradient: linear-gradient(135deg, #ff8c00 0%, #ff6b35 100%);
+  --orange-light: #ffa726;
+  --orange-dark: #e65100;
 }
 
 /* Verbesserte Basis-Styles */
@@ -2067,6 +2073,30 @@ footer a:hover {
 .feedback-message .bot-avatar {
   background: var(--accent-color);
   border: 2px solid rgba(255,255,255,0.2);
+}
+
+/* Orange Support-Optionen Styles */
+.hilfe-panel-header.orange-support {
+  background: var(--orange-gradient) !important;
+}
+
+.chatbot-header.orange-support {
+  background: var(--orange-gradient) !important;
+}
+
+.message-text.orange-support {
+  background: var(--orange-gradient) !important;
+  color: white !important;
+}
+
+.bot-avatar.orange-support {
+  background: var(--orange-gradient) !important;
+}
+
+.quick-topic-btn.orange-support:hover {
+  background: var(--orange-gradient) !important;
+  color: white !important;
+  border-color: transparent !important;
 }
 
 /* Mobile Anpassungen für Chatbot */


### PR DESCRIPTION
Dynamically change support section colors to orange upon option selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-29d3817f-f072-4d27-92d4-e3f204c8bae0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29d3817f-f072-4d27-92d4-e3f204c8bae0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>