### PR TITLE
Fix missing up arrow

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@ if (searchInput && mobileSearchBtn) {
       }
     </script>
     <!-- Nach oben Button -->
-    <button id="scrollToTopBtn" aria-label="Nach oben" style="display:none; position:fixed; bottom:100px; left:30px; z-index:9998; width:56px; height:56px; border-radius:50%; background:linear-gradient(135deg,#667eea,#764ba2); color:#fff; border:none; box-shadow:0 4px 16px rgba(102,126,234,0.18); font-size:2rem; display:flex; align-items:center; justify-content:center; transition:background 0.2s, box-shadow 0.2s; cursor:pointer;">
+    <button id="scrollToTopBtn" aria-label="Nach oben" style="position:fixed; bottom:100px; left:30px; z-index:9998; width:56px; height:56px; border-radius:50%; background:linear-gradient(135deg,#667eea,#764ba2); color:#fff; border:none; box-shadow:0 4px 16px rgba(102,126,234,0.18); font-size:2rem; display:flex; align-items:center; justify-content:center; transition:background 0.2s, box-shadow 0.2s; cursor:pointer;">
       <span style="display:flex; align-items:center; justify-content:center; width:100%; height:100%;"><i class="bi bi-arrow-up"></i></span>
     </button>
     <script>


### PR DESCRIPTION
Make the scroll-to-top button visible by removing a conflicting `display:none;` inline style.

---
<a href="https://cursor.com/background-agent?bcId=bc-195edae3-b5f1-41a6-9f64-2562c0632e64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-195edae3-b5f1-41a6-9f64-2562c0632e64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Bug Fixes:
- Show the scroll-to-top button by removing its inline display:none style