### PR TITLE
Expand help support button to full screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -368,6 +368,11 @@ if (searchInput && mobileSearchBtn) {
     console.log('Initial hilfePanel opacity:', window.getComputedStyle(hilfePanel).opacity);
   }
   
+  // Function to check if device is mobile
+  function isMobileDevice() {
+    return window.innerWidth <= 768 || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+  }
+
   // Event Listener für Hilfe-Button
   if (hilfeButton) {
     hilfeButton.addEventListener('click', (e) => {
@@ -384,6 +389,11 @@ if (searchInput && mobileSearchBtn) {
         hilfePanel.classList.remove('offen');
         document.body.classList.remove('help-panel-open');
         hilfePanel.style.display = 'none';
+        
+        // Restore body styles (especially important for mobile)
+        document.body.style.overflow = '';
+        document.body.style.height = '';
+        
         hideChatbot();
         console.log('Panel geschlossen');
       } else {
@@ -398,14 +408,39 @@ if (searchInput && mobileSearchBtn) {
         hilfePanel.style.opacity = '1';
         hilfePanel.style.zIndex = '10001';
         hilfePanel.style.position = 'fixed';
-        hilfePanel.style.top = '50%';
-        hilfePanel.style.right = '20px';
-        hilfePanel.style.transform = 'translateY(-50%) scale(1)';
-        hilfePanel.style.width = '440px';
-        hilfePanel.style.maxWidth = '95vw';
-        hilfePanel.style.height = 'auto';
-        hilfePanel.style.minHeight = '500px';
-        hilfePanel.style.maxHeight = '650px';
+        
+        // Check if mobile device for fullscreen behavior
+        if (isMobileDevice()) {
+          // Mobile: Fullscreen styling
+          hilfePanel.style.top = '0';
+          hilfePanel.style.left = '0';
+          hilfePanel.style.right = '0';
+          hilfePanel.style.bottom = '0';
+          hilfePanel.style.transform = 'none';
+          hilfePanel.style.width = '100vw';
+          hilfePanel.style.height = '100vh';
+          hilfePanel.style.maxWidth = '100vw';
+          hilfePanel.style.maxHeight = '100vh';
+          hilfePanel.style.minHeight = '100vh';
+          hilfePanel.style.borderRadius = '0';
+          hilfePanel.style.border = 'none';
+          // Prevent scrolling on body
+          document.body.style.overflow = 'hidden';
+          document.body.style.height = '100vh';
+        } else {
+          // Desktop: Normal panel styling
+          hilfePanel.style.top = '50%';
+          hilfePanel.style.right = '20px';
+          hilfePanel.style.left = 'auto';
+          hilfePanel.style.bottom = 'auto';
+          hilfePanel.style.transform = 'translateY(-50%) scale(1)';
+          hilfePanel.style.width = '440px';
+          hilfePanel.style.maxWidth = '95vw';
+          hilfePanel.style.height = 'auto';
+          hilfePanel.style.minHeight = '500px';
+          hilfePanel.style.maxHeight = '650px';
+          hilfePanel.style.borderRadius = '28px';
+        }
       }
     });
   } else {
@@ -701,6 +736,11 @@ if (searchInput && mobileSearchBtn) {
       hilfePanel.classList.remove('offen');
       document.body.classList.remove('help-panel-open');
       hilfePanel.style.display = 'none';
+      
+      // Restore body styles (especially important for mobile)
+      document.body.style.overflow = '';
+      document.body.style.height = '';
+      
       hideChatbot();
       console.log('Panel sofort geschlossen');
     });

--- a/styles.css
+++ b/styles.css
@@ -1065,17 +1065,25 @@ div#hilfeButton,
 }
 
 @media (max-width: 768px) {
-  .hilfe-panel {
-    width: 100vw;
-    height: 100vh;
-    max-width: 100vw;
-    max-height: 100vh;
-    top: 0;
-    left: 0;
-    right: 0;
-    transform: none;
-    border-radius: 0;
-    border: none;
+  .hilfe-panel,
+  .hilfe-panel.offen,
+  div.hilfe-panel,
+  div.hilfe-panel.offen,
+  [id="hilfePanel"],
+  [id="hilfePanel"].offen {
+    width: 100vw !important;
+    height: 100vh !important;
+    max-width: 100vw !important;
+    max-height: 100vh !important;
+    min-height: 100vh !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    transform: none !important;
+    border-radius: 0 !important;
+    border: none !important;
+    position: fixed !important;
     background: 
       linear-gradient(145deg, rgba(255,255,255,0.98) 0%, rgba(255,255,255,0.95) 100%),
       radial-gradient(circle at top center, rgba(102, 126, 234, 0.08), transparent 60%),
@@ -1087,6 +1095,18 @@ div#hilfeButton,
   .hilfe-themen-modern {
     max-height: calc(100vh - 180px);
     padding: 20px;
+    overflow-y: auto;
+  }
+  
+  /* Ensure chatbot interface is also fullscreen on mobile */
+  .chatbot-interface {
+    height: 100vh !important;
+    max-height: 100vh !important;
+  }
+  
+  .chatbot-messages {
+    max-height: calc(100vh - 200px) !important;
+    overflow-y: auto;
   }
 
   @keyframes slideUpPanelMega {
@@ -1178,6 +1198,17 @@ body:has(.hilfe-panel.offen) {
 .help-panel-open {
   overflow: hidden !important;
   height: 100vh !important;
+}
+
+/* Mobile-specific body scroll prevention */
+@media (max-width: 768px) {
+  body:has(.hilfe-panel.offen),
+  body.help-panel-open {
+    overflow: hidden !important;
+    height: 100vh !important;
+    position: fixed !important;
+    width: 100% !important;
+  }
 }
 
 /* FORCE CORRECT POSITIONING - OVERRIDE ALL OTHER STYLES */


### PR DESCRIPTION
Make the help/support panel open in fullscreen on mobile devices by correcting conflicting inline styles and enhancing CSS.

---
<a href="https://cursor.com/background-agent?bcId=bc-1bf68732-5081-4a00-97f9-e53348d4216d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1bf68732-5081-4a00-97f9-e53348d4216d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

