### PR TITLE
Fix help and support screen cutoff

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <!-- Start cookieyes banner --> <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/8e12f1f6a93c31ea65a1052f/script.js"></script> <!-- End cookieyes banner -->
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0, minimum-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no, maximum-scale=1.0, minimum-scale=1.0">
     <title>Marktplatz - Startseite</title>
     <meta name="description" content="Online-Marktplatz mit besten Angeboten">
     <meta name="keywords" content="ecommerce, online shopping, elektronik, mode">
@@ -412,21 +412,21 @@ if (searchInput && mobileSearchBtn) {
         // Check if mobile device for fullscreen behavior
         if (isMobileDevice()) {
           // Mobile: Fullscreen styling
-          hilfePanel.style.top = '0';
-          hilfePanel.style.left = '0';
-          hilfePanel.style.right = '0';
-          hilfePanel.style.bottom = '0';
-          hilfePanel.style.transform = 'none';
-          hilfePanel.style.width = '100vw';
-          hilfePanel.style.height = '100vh';
-          hilfePanel.style.maxWidth = '100vw';
-          hilfePanel.style.maxHeight = '100vh';
-          hilfePanel.style.minHeight = '100vh';
-          hilfePanel.style.borderRadius = '0';
-          hilfePanel.style.border = 'none';
-          // Prevent scrolling on body
-          document.body.style.overflow = 'hidden';
-          document.body.style.height = '100vh';
+                     hilfePanel.style.top = 'env(safe-area-inset-top)';
+           hilfePanel.style.left = '0';
+           hilfePanel.style.right = '0';
+           hilfePanel.style.bottom = 'env(safe-area-inset-bottom)';
+           hilfePanel.style.transform = 'none';
+           hilfePanel.style.width = '100vw';
+           hilfePanel.style.height = 'calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom))';
+           hilfePanel.style.maxWidth = '100vw';
+           hilfePanel.style.maxHeight = 'calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom))';
+           hilfePanel.style.minHeight = 'calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom))';
+           hilfePanel.style.borderRadius = '0';
+           hilfePanel.style.border = 'none';
+           // Prevent scrolling on body
+           document.body.style.overflow = 'hidden';
+           document.body.style.height = '100vh';
         } else {
           // Desktop: Normal panel styling
           hilfePanel.style.top = '50%';

--- a/styles.css
+++ b/styles.css
@@ -1090,22 +1090,28 @@ div#hilfeButton,
       radial-gradient(circle at bottom center, rgba(118, 75, 162, 0.08), transparent 60%);
     animation: slideUpPanelMega 0.8s cubic-bezier(0.175, 0.885, 0.32, 1.275);
     overflow: hidden;
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
   }
   
+  .hilfe-panel-header {
+    padding-top: calc(28px + env(safe-area-inset-top));
+  }
+
   .hilfe-themen-modern {
-    max-height: calc(100vh - 180px);
+    max-height: calc(100vh - 180px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
     padding: 20px;
     overflow-y: auto;
   }
   
   /* Ensure chatbot interface is also fullscreen on mobile */
   .chatbot-interface {
-    height: 100vh !important;
-    max-height: 100vh !important;
+    height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important;
+    max-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important;
   }
   
   .chatbot-messages {
-    max-height: calc(100vh - 200px) !important;
+    max-height: calc(100vh - 200px - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important;
     overflow-y: auto;
   }
 
@@ -1139,6 +1145,7 @@ div#hilfeButton,
   .hilfe-panel-header {
     border-radius: 0;
     padding: 28px 24px;
+    padding-top: calc(28px + env(safe-area-inset-top));
     font-size: 1.4rem;
   }
 }
@@ -1149,7 +1156,7 @@ div#hilfeButton,
 
   .chatbot-header {
     border-radius: 0;
-    padding: 16px 20px;
+    padding: calc(16px + env(safe-area-inset-top)) 20px 16px 20px;
   }
 
   .message-text {


### PR DESCRIPTION
Adjusts mobile "Hilfe/Support" panel to prevent content from being cut off by the device's status bar.

The panel was not respecting safe-area insets on mobile devices. This PR adds `viewport-fit=cover` and applies `env(safe-area-inset-*)` to relevant elements to ensure proper padding and height calculation, making the entire panel content visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-645f3d54-f58d-4e27-88e2-f35732c2b171">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-645f3d54-f58d-4e27-88e2-f35732c2b171">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Enable safe-area support on mobile by adding viewport-fit=cover and applying env(safe-area-inset-*) in CSS and JavaScript to prevent the help/support panel and chatbot interface from being cut off by device notches or status bars.

Bug Fixes:
- Fix help/support panel cutoff on mobile by respecting safe-area insets in styles and scripts

Enhancements:
- Add viewport-fit=cover to the meta viewport tag for full-viewport coverage on devices with notches
- Apply env(safe-area-inset-*) paddings and margin adjustments to the help panel, header, thematic sections, and chatbot interface
- Adjust JavaScript panel positioning and height calculations to account for safe-area insets