### PR TITLE
Fix help and support display on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,27 +408,27 @@ if (searchInput && mobileSearchBtn) {
         hilfePanel.style.display = 'flex';
         hilfePanel.style.visibility = 'visible';
         hilfePanel.style.opacity = '1';
-        hilfePanel.style.zIndex = '10001';
+        hilfePanel.style.zIndex = '2147483647';
         hilfePanel.style.position = 'fixed';
         
         // Check if mobile device for fullscreen behavior
         if (isMobileDevice()) {
           // Mobile: Fullscreen styling
-                     hilfePanel.style.top = 'env(safe-area-inset-top)';
-           hilfePanel.style.left = '0';
-           hilfePanel.style.right = '0';
-           hilfePanel.style.bottom = 'env(safe-area-inset-bottom)';
-           hilfePanel.style.transform = 'none';
-           hilfePanel.style.width = '100vw';
-           hilfePanel.style.height = 'calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom))';
-           hilfePanel.style.maxWidth = '100vw';
-           hilfePanel.style.maxHeight = 'calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom))';
-           hilfePanel.style.minHeight = 'calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom))';
-           hilfePanel.style.borderRadius = '0';
-           hilfePanel.style.border = 'none';
-           // Prevent scrolling on body
-           document.body.style.overflow = 'hidden';
-           document.body.style.height = '100vh';
+          hilfePanel.style.top = '0';
+          hilfePanel.style.left = '0';
+          hilfePanel.style.right = '0';
+          hilfePanel.style.bottom = '0';
+          hilfePanel.style.transform = 'none';
+          hilfePanel.style.width = '100vw';
+          hilfePanel.style.height = '100vh';
+          hilfePanel.style.maxWidth = '100vw';
+          hilfePanel.style.maxHeight = '100vh';
+          hilfePanel.style.minHeight = '100vh';
+          hilfePanel.style.borderRadius = '0';
+          hilfePanel.style.border = 'none';
+          // Prevent scrolling on body
+          document.body.style.overflow = 'hidden';
+          document.body.style.height = '100vh';
         } else {
           // Desktop: Normal panel styling
           hilfePanel.style.top = '50%';

--- a/styles.css
+++ b/styles.css
@@ -1040,7 +1040,7 @@ div#hilfeButton,
     0 6px 16px rgba(118, 75, 162, 0.15),
     inset 0 1px 0 rgba(255, 255, 255, 0.8),
     inset 0 -1px 0 rgba(0, 0, 0, 0.05);
-  z-index: 10001;
+  z-index: 2147483647;
   max-width: 95vw;
   width: 440px;
   max-height: 85vh;
@@ -1090,12 +1090,15 @@ div#hilfeButton,
       radial-gradient(circle at bottom center, rgba(118, 75, 162, 0.08), transparent 60%);
     animation: slideUpPanelMega 0.8s cubic-bezier(0.175, 0.885, 0.32, 1.275);
     overflow: hidden;
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: env(safe-area-inset-bottom);
+    padding-top: calc(constant(safe-area-inset-top) + 12px);
+    padding-top: calc(env(safe-area-inset-top, 0px) + 12px);
+    padding-bottom: calc(constant(safe-area-inset-bottom) + 12px);
+    padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 12px);
   }
   
   .hilfe-panel-header {
-    padding-top: calc(28px + env(safe-area-inset-top));
+    padding-top: calc(28px + constant(safe-area-inset-top));
+    padding-top: calc(28px + env(safe-area-inset-top, 0px));
   }
 
   .hilfe-themen-modern {
@@ -1145,7 +1148,8 @@ div#hilfeButton,
   .hilfe-panel-header {
     border-radius: 0;
     padding: 28px 24px;
-    padding-top: calc(28px + env(safe-area-inset-top));
+    padding-top: calc(28px + constant(safe-area-inset-top));
+    padding-top: calc(28px + env(safe-area-inset-top, 0px));
     font-size: 1.4rem;
   }
 }
@@ -1156,7 +1160,8 @@ div#hilfeButton,
 
   .chatbot-header {
     border-radius: 0;
-    padding: calc(16px + env(safe-area-inset-top)) 20px 16px 20px;
+    padding: calc(16px + constant(safe-area-inset-top)) 20px 16px 20px;
+    padding: calc(16px + env(safe-area-inset-top, 0px)) 20px 16px 20px;
   }
 
   .message-text {
@@ -1239,7 +1244,7 @@ body:has(.hilfe-panel.offen) {
   visibility: visible !important;
   opacity: 1 !important;
   transform: translateY(-50%) scale(1) !important;
-  z-index: 10001 !important;
+  z-index: 2147483647 !important;
 }
 
 /* Additional force rule for panel visibility */
@@ -1249,7 +1254,7 @@ div#hilfePanel.offen,
   visibility: visible !important;
   opacity: 1 !important;
   transform: translateY(-50%) scale(1) !important;
-  z-index: 10001 !important;
+  z-index: 2147483647 !important;
   position: fixed !important;
   top: 50% !important;
   right: 20px !important;


### PR DESCRIPTION
Adjusts Help/Support panel and header styling to prevent content from being cut off on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-e83e2a62-5607-4aa1-bdbe-6a90d7761b5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e83e2a62-5607-4aa1-bdbe-6a90d7761b5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

