### PR TITLE
Fix quick order quantity arrows on product pages

### DIFF
--- a/produkte/produkt-1.html
+++ b/produkte/produkt-1.html
@@ -781,13 +781,22 @@
       });
     }
 
-    // Event-Listener für Quantity-Input
+    // Event-Listener für Quantity-Input (Mobile)
     const quantityInput = document.getElementById('quantity');
     if (quantityInput) {
       quantityInput.addEventListener('input', updateTotalPrice);
       quantityInput.addEventListener('change', updateTotalPrice);
-      updateTotalPrice(); // Initialisiere den Preis
     }
+
+    // Event-Listener für Quantity-Input (Desktop)
+    const quantityInputDesktop = document.getElementById('quantity-desktop');
+    if (quantityInputDesktop) {
+      quantityInputDesktop.addEventListener('input', updateTotalPrice);
+      quantityInputDesktop.addEventListener('change', updateTotalPrice);
+    }
+
+    // Initialisiere die Preise
+    updateTotalPrice();
     
     // Initialize all wishlist buttons with correct status
     updateAllWishlistButtons();

--- a/produkte/produkt-1.html
+++ b/produkte/produkt-1.html
@@ -87,9 +87,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             
@@ -99,7 +99,7 @@
                             </div>
                             
                             <div class="action-buttons">
-                                <button class="buy-now-btn wishlist-style-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn wishlist-style-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn wishlist-button" onclick="toggleWishlist(product)" data-product-id="1">
@@ -131,9 +131,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity-desktop" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             
@@ -143,7 +143,7 @@
                             </div>
                             
                             <div class="action-buttons">
-                                <button class="buy-now-btn wishlist-style-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn wishlist-style-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn wishlist-button" onclick="toggleWishlist(product)" data-product-id="1">
@@ -686,32 +686,64 @@
   }
 
   // Funktionen für die neue Schnellbestellung
-  function increaseQuantity() {
-    const input = document.getElementById('quantity');
-    const currentValue = parseInt(input.value, 10) || 1;
-    if (currentValue < 10) {
-      input.value = currentValue + 1;
-      updateTotalPrice();
+  function increaseQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const input = document.getElementById(inputId);
+    
+    if (input) {
+      const currentValue = parseInt(input.value, 10) || 1;
+      if (currentValue < 10) {
+        input.value = currentValue + 1;
+        updateTotalPrice();
+      }
     }
   }
 
-  function decreaseQuantity() {
-    const input = document.getElementById('quantity');
-    const currentValue = parseInt(input.value, 10) || 1;
-    if (currentValue > 1) {
-      input.value = currentValue - 1;
-      updateTotalPrice();
+  function decreaseQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const input = document.getElementById(inputId);
+    
+    if (input) {
+      const currentValue = parseInt(input.value, 10) || 1;
+      if (currentValue > 1) {
+        input.value = currentValue - 1;
+        updateTotalPrice();
+      }
     }
   }
 
   function updateTotalPrice() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
-    const total = (product.price * quantity).toFixed(2);
-    document.getElementById('totalPrice').textContent = total;
+    // Update both mobile and desktop total prices
+    const mobileQuantity = parseInt(document.getElementById('quantity')?.value, 10) || 1;
+    const desktopQuantity = parseInt(document.getElementById('quantity-desktop')?.value, 10) || 1;
+    
+    const mobileTotal = (product.price * mobileQuantity).toFixed(2);
+    const desktopTotal = (product.price * desktopQuantity).toFixed(2);
+    
+    const mobileTotalElement = document.getElementById('totalPrice');
+    const desktopTotalElement = document.getElementById('totalPriceDesktop');
+    
+    if (mobileTotalElement) mobileTotalElement.textContent = `€${mobileTotal}`;
+    if (desktopTotalElement) desktopTotalElement.textContent = `€${desktopTotal}`;
   }
 
-  function addToCartWithQuantity() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
+  function addToCartWithQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const quantityInput = document.getElementById(inputId);
+    const quantity = quantityInput ? parseInt(quantityInput.value, 10) || 1 : 1;
+    
     const productToCart = {
       ...product,
       quantity: quantity

--- a/produkte/produkt-10.html
+++ b/produkte/produkt-10.html
@@ -110,9 +110,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
@@ -120,7 +120,7 @@
                                 <div class="total-price">Gesamt: <span id="totalPrice">€40.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -150,9 +150,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             
@@ -543,21 +543,37 @@
     }, 2000);
   }
   // Funktionen für die neue Schnellbestellung
-  function increaseQuantity() {
-    const input = document.getElementById('quantity');
-    const currentValue = parseInt(input.value, 10) || 1;
-    if (currentValue < 10) {
-      input.value = currentValue + 1;
-      updateTotalPrice();
+  function increaseQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const input = document.getElementById(inputId);
+    
+    if (input) {
+      const currentValue = parseInt(input.value, 10) || 1;
+      if (currentValue < 10) {
+        input.value = currentValue + 1;
+        updateTotalPrice();
+      }
     }
   }
 
-  function decreaseQuantity() {
-    const input = document.getElementById('quantity');
-    const currentValue = parseInt(input.value, 10) || 1;
-    if (currentValue > 1) {
-      input.value = currentValue - 1;
-      updateTotalPrice();
+  function decreaseQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const input = document.getElementById(inputId);
+    
+    if (input) {
+      const currentValue = parseInt(input.value, 10) || 1;
+      if (currentValue > 1) {
+        input.value = currentValue - 1;
+        updateTotalPrice();
+      }
     }
   }
 

--- a/produkte/produkt-10.html.backup
+++ b/produkte/produkt-10.html.backup
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Haushalt Produkt 3 - Marktplatz</title>
+    <title>Haushalt Produkt 1 - Marktplatz</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link href="haushalt.css" rel="stylesheet">
@@ -54,10 +54,10 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-6">
-                    <h1 class="display-4 fw-bold mb-3">Haushalt Produkt 3</h1>
+                    <h1 class="display-4 fw-bold mb-3">Haushalt Produkt 1</h1>
                     <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
                     <div class="d-flex align-items-center gap-3 mb-4">
-                        <span class="price-tag">€44.00</span>
+                        <span class="price-tag">€40.00</span>
                         <span class="badge bg-success">Kostenloser Versand in Europa</span>
                     </div>
                     <button class="btn btn-light btn-lg me-3" id="cartBtn">
@@ -68,7 +68,7 @@
                     </button>
                 </div>
                 <div class="col-lg-6 text-center">
-                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
+                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 1" class="img-fluid product-image" style="max-height: 400px;">
                 </div>
             </div>
         </div>
@@ -91,8 +91,8 @@
                     <div class="row">
                         <div class="col-md-6">
                             <p><strong>Kategorie:</strong> Haushalt</p>
-                            <p><strong>Artikelnummer:</strong> 012</p>
-                            <p><strong>Preis:</strong> €44.00</p>
+                            <p><strong>Artikelnummer:</strong> 010</p>
+                            <p><strong>Preis:</strong> €40.00</p>
                         </div>
                         <div class="col-md-6">
                             <p><strong>Verfügbarkeit:</strong> Auf Lager</p>
@@ -110,17 +110,17 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€40.00</div>
+                                <div class="total-price">Gesamt: <span id="totalPrice">€40.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -150,15 +150,15 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€40.00</div>
+                                <div class="total-price">Gesamt: <span id="totalPrice">€40.00</span></div>
                             </div>
                             
                             <div class="action-buttons">
@@ -195,13 +195,13 @@
                 </div>
                 <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3 g-md-4">
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-10.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-11.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 1">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 2">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Haushalt Produkt 1</h5>
-                            <div class="price-container"><span class="current-price">€15.00</span></div>
+                            <h5 class="product-title">Haushalt Produkt 2</h5>
+                            <div class="price-container"><span class="current-price">€18.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -210,13 +210,13 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-11.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-12.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 2">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 3">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Haushalt Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€18.00</span></div>
+                            <h5 class="product-title">Haushalt Produkt 3</h5>
+                            <div class="price-container"><span class="current-price">€20.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -269,11 +269,11 @@
     <script>
   // Produktdaten für diese Seite
   const product = {
-    id: 12,
-    name: "Haushalt Produkt 3",
-    price: 44.00,
+    id: 10,
+    name: "Haushalt Produkt 1",
+    price: 40.00,
     image: "produkt bilder/ware.png",
-    description: "Praktisch und zuverlässig für Ihr Zuhause."
+    description: "Praktisch und zuverlässig für Ihr Zuhause. Dieses hochwertige Produkt bietet die perfekte Balance zwischen Funktionalität und Design."
   };
 
   // Bundles dynamisch laden
@@ -288,6 +288,117 @@
         renderBundles();
       }
     });
+
+  function renderBundles() {
+    const einzelpreis = 40.00;
+    const staffel = [
+      {qty:1, price:einzelpreis, original:einzelpreis},
+      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
+      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
+    ];
+    const section = document.getElementById('bundle-section');
+    let selected = 1;
+    section.innerHTML = `
+      <div class="bundle-box">
+        <div class="bundle-header">BUNDLE & SPARE</div>
+        <form id="bundleForm">
+          ${staffel.map((s, i) => `
+            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
+              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
+              <div class="bundle-info">
+                <div class="bundle-title">
+                  ${s.qty} Set${s.qty>1?'s':''} kaufen
+                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
+                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
+                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
+                </div>
+                <div class="bundle-prices">
+                  €${s.price.toFixed(2)} pro Set
+                  <span class="old">€${s.original.toFixed(2)}</span>
+                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
+                </div>
+                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
+              </div>
+            </div>
+          `).join('')}
+          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
+        </form>
+      </div>
+    `;
+    // Interaktive Auswahl
+    const cards = section.querySelectorAll('.bundle-card');
+    const radios = section.querySelectorAll('.bundle-radio');
+    
+    // Event-Listener für Radio-Buttons
+    radios.forEach((radio, i) => {
+      radio.addEventListener('change', () => {
+        cards.forEach(c => c.classList.remove('selected'));
+        cards[i].classList.add('selected');
+      });
+    });
+
+    // Event-Listener für Bundle-Cards
+    cards.forEach((card, i) => {
+      card.addEventListener('click', (e) => {
+        // Verhindere Bubbling wenn auf Radio geklickt wurde
+        if (e.target === radios[i]) return;
+        
+        // Wähle Radio-Button aus
+        radios[i].checked = true;
+        
+        // Aktualisiere Selected-Status
+        cards.forEach(c => c.classList.remove('selected'));
+        card.classList.add('selected');
+        
+        // Trigger change Event auf Radio
+        radios[i].dispatchEvent(new Event('change'));
+      });
+    });
+
+    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      const idx = Array.from(radios).findIndex(r => r.checked);
+      const s = staffel[idx];
+      addBundleToCart({
+        id: product.id,
+        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
+        price: s.price * s.qty, // Gesamtpreis für das Bundle
+        image: product.image,
+        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
+        bundleId: `${product.id}-qty${s.qty}`,
+        quantity: 1
+      });
+    });
+  }
+
+  function addBundleToCart(bundle) {
+    let cart = getCart();
+    // Bundle als eigenes Cart-Item mit bundleId
+    const bundleId = bundle.bundleId;
+    const existing = cart.find(item => item.bundleId === bundleId);
+    if (existing) {
+      // Bei Bundles immer nur 1 erlauben
+      existing.quantity = 1;
+    } else {
+      cart.push({
+        id: product.id,
+        name: bundle.name,
+        price: bundle.price,
+        image: product.image,
+        description: bundle.description,
+        bundleId: bundleId,
+        bundleItems: [], // Keine Items für die neue Staffel
+        quantity: 1
+      });
+    }
+    setCart(cart);
+    // Popup anzeigen statt direkter Weiterleitung
+    if (typeof showAlert === 'function') {
+      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
+    } else {
+      showNotification('Bundle zum Warenkorb hinzugefügt');
+    }
+  }
 
   function getWishlist() {
     return JSON.parse(localStorage.getItem('wishlist')) || [];
@@ -431,150 +542,22 @@
       }
     }, 2000);
   }
-
-  function addBundleToCart(bundle) {
-    let cart = getCart();
-    const bundleId = bundle.bundleId;
-    const existing = cart.find(item => item.bundleId === bundleId);
-    if (existing) {
-        existing.quantity = 1;
-    } else {
-        cart.push({
-            id: product.id,
-            name: bundle.name,
-            price: bundle.price,
-            image: product.image,
-            description: bundle.description,
-            bundleId: bundleId,
-            bundleItems: [], // Keine Items für die neue Staffel
-            quantity: 1
-        });
-    }
-    setCart(cart);
-    // Popup anzeigen statt direkter Weiterleitung
-    if (typeof showAlert === 'function') {
-      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
-    } else {
-      showNotification('Bundle zum Warenkorb hinzugefügt');
-    }
-}
-
-  function renderBundles() {
-    const einzelpreis = 44.00;
-    const staffel = [
-      {qty:1, price:einzelpreis, original:einzelpreis},
-      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
-      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
-    ];
-    const section = document.getElementById('bundle-section');
-    let selected = 1;
-    section.innerHTML = `
-      <div class="bundle-box">
-        <div class="bundle-header">BUNDLE & SPARE</div>
-        <form id="bundleForm">
-          ${staffel.map((s, i) => `
-            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
-              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
-              <div class="bundle-info">
-                <div class="bundle-title">
-                  ${s.qty} Set${s.qty>1?'s':''} kaufen
-                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
-                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
-                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
-                </div>
-                <div class="bundle-prices">
-                  €${s.price.toFixed(2)} pro Set
-                  <span class="old">€${s.original.toFixed(2)}</span>
-                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
-                </div>
-                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
-              </div>
-            </div>
-          `).join('')}
-          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
-        </form>
-      </div>
-    `;
-    // Interaktive Auswahl
-    const cards = section.querySelectorAll('.bundle-card');
-    const radios = section.querySelectorAll('.bundle-radio');
-    
-    // Event-Listener für Radio-Buttons
-    radios.forEach((radio, i) => {
-      radio.addEventListener('change', () => {
-        cards.forEach(c => c.classList.remove('selected'));
-        cards[i].classList.add('selected');
-      });
-    });
-
-    // Event-Listener für Bundle-Cards
-    cards.forEach((card, i) => {
-      card.addEventListener('click', (e) => {
-        // Verhindere Bubbling wenn auf Radio geklickt wurde
-        if (e.target === radios[i]) return;
-        
-        // Wähle Radio-Button aus
-        radios[i].checked = true;
-        
-        // Aktualisiere Selected-Status
-        cards.forEach(c => c.classList.remove('selected'));
-        card.classList.add('selected');
-        
-        // Trigger change Event auf Radio
-        radios[i].dispatchEvent(new Event('change'));
-      });
-    });
-
-    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
-      e.preventDefault();
-      const idx = Array.from(radios).findIndex(r => r.checked);
-      const s = staffel[idx];
-      addBundleToCart({
-        id: product.id,
-        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
-        price: s.price * s.qty,
-        image: product.image,
-        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
-        bundleId: `${product.id}-qty${s.qty}`,
-        quantity: s.qty
-      });
-    });
-  }
-
-  renderBundles();
-
   // Funktionen für die neue Schnellbestellung
-  function increaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue < 10) {
-        input.value = currentValue + 1;
-        updateTotalPrice();
-      }
+  function increaseQuantity() {
+    const input = document.getElementById('quantity');
+    const currentValue = parseInt(input.value, 10) || 1;
+    if (currentValue < 10) {
+      input.value = currentValue + 1;
+      updateTotalPrice();
     }
   }
 
-  function decreaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue > 1) {
-        input.value = currentValue - 1;
-        updateTotalPrice();
-      }
+  function decreaseQuantity() {
+    const input = document.getElementById('quantity');
+    const currentValue = parseInt(input.value, 10) || 1;
+    if (currentValue > 1) {
+      input.value = currentValue - 1;
+      updateTotalPrice();
     }
   }
 

--- a/produkte/produkt-11.html
+++ b/produkte/produkt-11.html
@@ -110,9 +110,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
@@ -120,7 +120,7 @@
                                 <div class="total-price">Gesamt: <span id="totalPrice">€42.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -150,9 +150,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             
@@ -568,21 +568,37 @@
 
   renderBundles();
   // Funktionen für die neue Schnellbestellung
-  function increaseQuantity() {
-    const input = document.getElementById('quantity');
-    const currentValue = parseInt(input.value, 10) || 1;
-    if (currentValue < 10) {
-      input.value = currentValue + 1;
-      updateTotalPrice();
+  function increaseQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const input = document.getElementById(inputId);
+    
+    if (input) {
+      const currentValue = parseInt(input.value, 10) || 1;
+      if (currentValue < 10) {
+        input.value = currentValue + 1;
+        updateTotalPrice();
+      }
     }
   }
 
-  function decreaseQuantity() {
-    const input = document.getElementById('quantity');
-    const currentValue = parseInt(input.value, 10) || 1;
-    if (currentValue > 1) {
-      input.value = currentValue - 1;
-      updateTotalPrice();
+  function decreaseQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const input = document.getElementById(inputId);
+    
+    if (input) {
+      const currentValue = parseInt(input.value, 10) || 1;
+      if (currentValue > 1) {
+        input.value = currentValue - 1;
+        updateTotalPrice();
+      }
     }
   }
 

--- a/produkte/produkt-11.html.backup
+++ b/produkte/produkt-11.html.backup
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Haushalt Produkt 3 - Marktplatz</title>
+    <title>Haushalt Produkt 2 - Marktplatz</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link href="haushalt.css" rel="stylesheet">
@@ -54,10 +54,10 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-6">
-                    <h1 class="display-4 fw-bold mb-3">Haushalt Produkt 3</h1>
+                    <h1 class="display-4 fw-bold mb-3">Haushalt Produkt 2</h1>
                     <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
                     <div class="d-flex align-items-center gap-3 mb-4">
-                        <span class="price-tag">€44.00</span>
+                        <span class="price-tag">€42.00</span>
                         <span class="badge bg-success">Kostenloser Versand in Europa</span>
                     </div>
                     <button class="btn btn-light btn-lg me-3" id="cartBtn">
@@ -68,7 +68,7 @@
                     </button>
                 </div>
                 <div class="col-lg-6 text-center">
-                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
+                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 2" class="img-fluid product-image" style="max-height: 400px;">
                 </div>
             </div>
         </div>
@@ -91,8 +91,8 @@
                     <div class="row">
                         <div class="col-md-6">
                             <p><strong>Kategorie:</strong> Haushalt</p>
-                            <p><strong>Artikelnummer:</strong> 012</p>
-                            <p><strong>Preis:</strong> €44.00</p>
+                            <p><strong>Artikelnummer:</strong> 011</p>
+                            <p><strong>Preis:</strong> €42.00</p>
                         </div>
                         <div class="col-md-6">
                             <p><strong>Verfügbarkeit:</strong> Auf Lager</p>
@@ -110,17 +110,17 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€42.00</div>
+                                <div class="total-price">Gesamt: <span id="totalPrice">€42.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -150,15 +150,15 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€42.00</div>
+                                <div class="total-price">Gesamt: <span id="totalPrice">€42.00</span></div>
                             </div>
                             
                             <div class="action-buttons">
@@ -210,13 +210,13 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-11.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-12.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 2">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 3">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Haushalt Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€18.00</span></div>
+                            <h5 class="product-title">Haushalt Produkt 3</h5>
+                            <div class="price-container"><span class="current-price">€20.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -269,9 +269,9 @@
     <script>
   // Produktdaten für diese Seite
   const product = {
-    id: 12,
-    name: "Haushalt Produkt 3",
-    price: 44.00,
+    id: 11,
+    name: "Haushalt Produkt 2",
+    price: 42.00,
     image: "produkt bilder/ware.png",
     description: "Praktisch und zuverlässig für Ihr Zuhause."
   };
@@ -345,9 +345,9 @@
       let cart = getCart();
       const existing = cart.find(item => Number(item.id) === Number(product.id));
       if (existing) {
-          existing.quantity += product.quantity || 1;
+          existing.quantity++;
       } else {
-          cart.push({ ...product, quantity: product.quantity || 1 });
+          cart.push({ ...product, quantity: 1 });
       }
       setCart(cart);
       // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
@@ -434,33 +434,29 @@
 
   function addBundleToCart(bundle) {
     let cart = getCart();
+    // Bundle als eigenes Cart-Item mit bundleId
     const bundleId = bundle.bundleId;
     const existing = cart.find(item => item.bundleId === bundleId);
     if (existing) {
-        existing.quantity = 1;
+      // Bei Bundles immer nur 1 erlauben
+      existing.quantity = 1;
     } else {
-        cart.push({
-            id: product.id,
-            name: bundle.name,
-            price: bundle.price,
-            image: product.image,
-            description: bundle.description,
-            bundleId: bundleId,
-            bundleItems: [], // Keine Items für die neue Staffel
-            quantity: 1
-        });
+      cart.push({
+        id: product.id,
+        name: bundle.name,
+        price: bundle.price,
+        image: product.image,
+        description: bundle.description,
+        bundleId: bundleId,
+        bundleItems: [], // Keine Items für die neue Staffel
+        quantity: 1
+      });
     }
     setCart(cart);
-    // Popup anzeigen statt direkter Weiterleitung
-    if (typeof showAlert === 'function') {
-      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
-    } else {
-      showNotification('Bundle zum Warenkorb hinzugefügt');
-    }
-}
-
+    window.location.href = '../cart.html';
+  }
   function renderBundles() {
-    const einzelpreis = 44.00;
+    const einzelpreis = 42.00;
     const staffel = [
       {qty:1, price:einzelpreis, original:einzelpreis},
       {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
@@ -532,7 +528,7 @@
       addBundleToCart({
         id: product.id,
         name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
-        price: s.price * s.qty,
+        price: s.price * s.qty, // Gesamtpreis für das Bundle
         image: product.image,
         description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
         bundleId: `${product.id}-qty${s.qty}`,
@@ -541,40 +537,52 @@
     });
   }
 
-  renderBundles();
-
-  // Funktionen für die neue Schnellbestellung
-  function increaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue < 10) {
-        input.value = currentValue + 1;
-        updateTotalPrice();
-      }
+  function addBundleToCart(bundle) {
+    let cart = getCart();
+    // Bundle als eigenes Cart-Item mit bundleId
+    const bundleId = bundle.bundleId;
+    const existing = cart.find(item => item.bundleId === bundleId);
+    if (existing) {
+      // Bei Bundles immer nur 1 erlauben
+      existing.quantity = 1;
+    } else {
+      cart.push({
+        id: product.id,
+        name: bundle.name,
+        price: bundle.price,
+        image: product.image,
+        description: bundle.description,
+        bundleId: bundleId,
+        bundleItems: [], // Keine Items für die neue Staffel
+        quantity: 1
+      });
+    }
+    setCart(cart);
+    // Popup anzeigen statt direkter Weiterleitung
+    if (typeof showAlert === 'function') {
+      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
+    } else {
+      showNotification('Bundle zum Warenkorb hinzugefügt');
     }
   }
 
-  function decreaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue > 1) {
-        input.value = currentValue - 1;
-        updateTotalPrice();
-      }
+  renderBundles();
+  // Funktionen für die neue Schnellbestellung
+  function increaseQuantity() {
+    const input = document.getElementById('quantity');
+    const currentValue = parseInt(input.value, 10) || 1;
+    if (currentValue < 10) {
+      input.value = currentValue + 1;
+      updateTotalPrice();
+    }
+  }
+
+  function decreaseQuantity() {
+    const input = document.getElementById('quantity');
+    const currentValue = parseInt(input.value, 10) || 1;
+    if (currentValue > 1) {
+      input.value = currentValue - 1;
+      updateTotalPrice();
     }
   }
 

--- a/produkte/produkt-12.html.backup
+++ b/produkte/produkt-12.html.backup
@@ -110,9 +110,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
@@ -120,7 +120,7 @@
                                 <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -150,9 +150,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             
@@ -544,37 +544,21 @@
   renderBundles();
 
   // Funktionen für die neue Schnellbestellung
-  function increaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue < 10) {
-        input.value = currentValue + 1;
-        updateTotalPrice();
-      }
+  function increaseQuantity() {
+    const input = document.getElementById('quantity');
+    const currentValue = parseInt(input.value, 10) || 1;
+    if (currentValue < 10) {
+      input.value = currentValue + 1;
+      updateTotalPrice();
     }
   }
 
-  function decreaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue > 1) {
-        input.value = currentValue - 1;
-        updateTotalPrice();
-      }
+  function decreaseQuantity() {
+    const input = document.getElementById('quantity');
+    const currentValue = parseInt(input.value, 10) || 1;
+    if (currentValue > 1) {
+      input.value = currentValue - 1;
+      updateTotalPrice();
     }
   }
 

--- a/produkte/produkt-2.html
+++ b/produkte/produkt-2.html
@@ -87,9 +87,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             
@@ -131,9 +131,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity-desktop" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             
@@ -533,32 +533,64 @@
   }
 
   // Funktionen für die neue Schnellbestellung
-  function increaseQuantity() {
-    const input = document.getElementById('quantity');
-    const currentValue = parseInt(input.value, 10) || 1;
-    if (currentValue < 10) {
-      input.value = currentValue + 1;
-      updateTotalPrice();
+  function increaseQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const input = document.getElementById(inputId);
+    
+    if (input) {
+      const currentValue = parseInt(input.value, 10) || 1;
+      if (currentValue < 10) {
+        input.value = currentValue + 1;
+        updateTotalPrice();
+      }
     }
   }
 
-  function decreaseQuantity() {
-    const input = document.getElementById('quantity');
-    const currentValue = parseInt(input.value, 10) || 1;
-    if (currentValue > 1) {
-      input.value = currentValue - 1;
-      updateTotalPrice();
+  function decreaseQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const input = document.getElementById(inputId);
+    
+    if (input) {
+      const currentValue = parseInt(input.value, 10) || 1;
+      if (currentValue > 1) {
+        input.value = currentValue - 1;
+        updateTotalPrice();
+      }
     }
   }
 
   function updateTotalPrice() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
-    const total = (product.price * quantity).toFixed(2);
-    document.getElementById('totalPrice').textContent = `€${total}`;
+    // Update both mobile and desktop total prices
+    const mobileQuantity = parseInt(document.getElementById('quantity')?.value, 10) || 1;
+    const desktopQuantity = parseInt(document.getElementById('quantity-desktop')?.value, 10) || 1;
+    
+    const mobileTotal = (product.price * mobileQuantity).toFixed(2);
+    const desktopTotal = (product.price * desktopQuantity).toFixed(2);
+    
+    const mobileTotalElement = document.getElementById('totalPrice');
+    const desktopTotalElement = document.getElementById('totalPriceDesktop');
+    
+    if (mobileTotalElement) mobileTotalElement.textContent = `€${mobileTotal}`;
+    if (desktopTotalElement) desktopTotalElement.textContent = `€${desktopTotal}`;
   }
 
-  function addToCartWithQuantity() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
+  function addToCartWithQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const quantityInput = document.getElementById(inputId);
+    const quantity = quantityInput ? parseInt(quantityInput.value, 10) || 1 : 1;
+    
     const productToCart = {
       id: product.id,
       name: product.name,

--- a/produkte/produkt-2.html
+++ b/produkte/produkt-2.html
@@ -99,7 +99,7 @@
                             </div>
                             
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -143,7 +143,7 @@
                             </div>
                             
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -647,13 +647,22 @@
     // Update both wishlist buttons on page load
     updateWishlistButton();
     
-    // Event-Listener für Quantity-Input
+    // Event-Listener für Quantity-Input (Mobile)
     const quantityInput = document.getElementById('quantity');
     if (quantityInput) {
       quantityInput.addEventListener('input', updateTotalPrice);
       quantityInput.addEventListener('change', updateTotalPrice);
-      updateTotalPrice(); // Initialisiere den Preis
     }
+
+    // Event-Listener für Quantity-Input (Desktop)
+    const quantityInputDesktop = document.getElementById('quantity-desktop');
+    if (quantityInputDesktop) {
+      quantityInputDesktop.addEventListener('input', updateTotalPrice);
+      quantityInputDesktop.addEventListener('change', updateTotalPrice);
+    }
+
+    // Initialisiere die Preise
+    updateTotalPrice();
   });
 </script>
 </body>

--- a/produkte/produkt-3.html
+++ b/produkte/produkt-3.html
@@ -87,9 +87,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             
@@ -99,7 +99,7 @@
                             </div>
                             
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -131,9 +131,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity-desktop" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             
@@ -143,7 +143,7 @@
                             </div>
                             
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -522,32 +522,63 @@
   }
 
   // Funktionen für die neue Schnellbestellung
-  function increaseQuantity() {
-    const input = document.getElementById('quantity');
-    const currentValue = parseInt(input.value, 10) || 1;
-    if (currentValue < 10) {
-      input.value = currentValue + 1;
-      updateTotalPrice();
+  function increaseQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const input = document.getElementById(inputId);
+    
+    if (input) {
+      const currentValue = parseInt(input.value, 10) || 1;
+      if (currentValue < 10) {
+        input.value = currentValue + 1;
+        updateTotalPrice();
+      }
     }
   }
 
-  function decreaseQuantity() {
-    const input = document.getElementById('quantity');
-    const currentValue = parseInt(input.value, 10) || 1;
-    if (currentValue > 1) {
-      input.value = currentValue - 1;
-      updateTotalPrice();
+  function decreaseQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const input = document.getElementById(inputId);
+    
+    if (input) {
+      const currentValue = parseInt(input.value, 10) || 1;
+      if (currentValue > 1) {
+        input.value = currentValue - 1;
+        updateTotalPrice();
+      }
     }
   }
 
   function updateTotalPrice() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
-    const total = (product.price * quantity).toFixed(2);
-    document.getElementById('totalPrice').textContent = total;
+    // Update both mobile and desktop total prices
+    const mobileQuantity = parseInt(document.getElementById('quantity')?.value, 10) || 1;
+    const desktopQuantity = parseInt(document.getElementById('quantity-desktop')?.value, 10) || 1;
+    
+    const mobileTotal = (product.price * mobileQuantity).toFixed(2);
+    const desktopTotal = (product.price * desktopQuantity).toFixed(2);
+    
+    const mobileTotalElement = document.getElementById('totalPrice');
+    const desktopTotalElement = document.getElementById('totalPriceDesktop');
+    
+    if (mobileTotalElement) mobileTotalElement.textContent = `€${mobileTotal}`;
+    if (desktopTotalElement) desktopTotalElement.textContent = `€${desktopTotal}`;
   }
 
-  function addToCartWithQuantity() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
+  function addToCartWithQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const quantityInput = document.getElementById(inputId);
+    const quantity = quantityInput ? parseInt(quantityInput.value, 10) || 1 : 1;
     const productToCart = {
       ...product,
       quantity: quantity
@@ -587,13 +618,22 @@
       updateWishlistButton();
     }
 
-    // Event-Listener für Quantity-Input
+    // Event-Listener für Quantity-Input (Mobile)
     const quantityInput = document.getElementById('quantity');
     if (quantityInput) {
       quantityInput.addEventListener('input', updateTotalPrice);
       quantityInput.addEventListener('change', updateTotalPrice);
-      updateTotalPrice(); // Initialisiere den Preis
     }
+
+    // Event-Listener für Quantity-Input (Desktop)
+    const quantityInputDesktop = document.getElementById('quantity-desktop');
+    if (quantityInputDesktop) {
+      quantityInputDesktop.addEventListener('input', updateTotalPrice);
+      quantityInputDesktop.addEventListener('change', updateTotalPrice);
+    }
+
+    // Initialisiere die Preise
+    updateTotalPrice();
   });
     </script>
 </body>

--- a/produkte/produkt-3.html.backup
+++ b/produkte/produkt-3.html.backup
@@ -3,33 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Haushalt Produkt 3 - Marktplatz</title>
+    <title>Elektronik Produkt 3 - Marktplatz</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <link href="haushalt.css" rel="stylesheet">
-    <style>
-        .product-hero {
-            background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
-            color: white;
-            padding: 4rem 0;
-        }
-        .product-image {
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-            transition: transform 0.3s ease;
-        }
-        .product-image:hover {
-            transform: scale(1.02);
-        }
-        .price-tag {
-            background: linear-gradient(45deg, #ff6b6b, #ee5a24);
-            color: white;
-            padding: 0.5rem 1.5rem;
-            border-radius: 25px;
-            font-weight: bold;
-            font-size: 1.5rem;
-        }
-    </style>
+    <link href="elektronik.css" rel="stylesheet">
 </head>
 <body>
     <!-- Navigation -->
@@ -54,21 +31,21 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-6">
-                    <h1 class="display-4 fw-bold mb-3">Haushalt Produkt 3</h1>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <h1 class="display-4 fw-bold mb-3">Elektronik Produkt 3</h1>
+                    <p class="lead mb-4">Beschreibungstext für Produkt 3</p>
                     <div class="d-flex align-items-center gap-3 mb-4">
-                        <span class="price-tag">€44.00</span>
+                        <span class="price-tag">€14.00</span>
                         <span class="badge bg-success">Kostenloser Versand in Europa</span>
                     </div>
                     <button class="btn btn-light btn-lg me-3" id="cartBtn">
                         <i class="bi bi-cart-plus"></i> In den Warenkorb
                     </button>
                     <button class="btn btn-outline-light btn-lg" id="wishlistBtn">
-                        <i class="bi bi-heart"></i> Merken
+                        <i class="bi bi-heart"></i> Zur Wunschliste
                     </button>
                 </div>
                 <div class="col-lg-6 text-center">
-                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
+                    <img src="../produkt bilder/ware.png" alt="Elektronik Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
                 </div>
             </div>
         </div>
@@ -80,19 +57,19 @@
             <div class="row">
                 <div class="col-lg-8">
                     <h2 class="mb-4">Produktbeschreibung</h2>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <p class="lead mb-4">Innovative Technologie für Ihren Alltag. Dieses hochwertige Produkt bietet die perfekte Balance zwischen Funktionalität und Design.</p>
                     
                     <h3>Hauptmerkmale</h3>
                     <ul class="list-unstyled">
-                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Robuste Konstruktion</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Einfache Bedienung</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Platzsparend</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Wartungsarm</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>3 Jahre Garantie</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Hochwertige Materialien</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Langlebige Konstruktion</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Benutzerfreundliches Design</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Energieeffizient</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>2 Jahre Garantie</li>
                     </ul>
 
                     <h3 class="mt-4">Technische Spezifikationen</h3>
                     <div class="row">
                         <div class="col-md-6">
-                            <p><strong>Kategorie:</strong> Haushalt</p>
-                            <p><strong>Artikelnummer:</strong> 012</p>
-                            <p><strong>Preis:</strong> €44.00</p>
+                            <p><strong>Kategorie:</strong> Elektronik</p>
+                            <p><strong>Artikelnummer:</strong> 003</p>
+                            <p><strong>Preis:</strong> €14.00</p>
                         </div>
                         <div class="col-md-6">
                             <p><strong>Verfügbarkeit:</strong> Auf Lager</p>
@@ -110,23 +87,26 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
+                            
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€14.00</div>
+                                <div class="total-price">Gesamt: <span id="totalPrice">€14.00</span></div>
                             </div>
+                            
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
                                     <i class="bi bi-heart"></i> Zur Wunschliste
                                 </button>
                             </div>
+                            
                             <div class="features-section">
                                 <ul class="features-list">
                                     <li><i class="bi bi-truck"></i> Kostenloser Versand in Europa</li>
@@ -142,6 +122,7 @@
                 </div>
                 
                 <div class="col-lg-4">
+                    <!-- Schnellbestellung (Desktop only) -->
                     <div class="quick-order-card d-none d-lg-block">
                         <div class="quick-order-header">
                             <h4>Schnellbestellung</h4>
@@ -150,23 +131,23 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
-                                    <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <input type="number" class="quantity-input" id="quantity-desktop" value="1" min="1" max="10">
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€14.00</div>
+                                <div class="total-price">Gesamt: <span id="totalPriceDesktop">€14.00</span></div>
                             </div>
                             
                             <div class="action-buttons">
-                                <button class="buy-now-btn" id="buyNowBtn">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
-                                    <i class="bi bi-heart"></i> Zur Wunschliste hinzufügen
+                                    <i class="bi bi-heart"></i> Zur Wunschliste
                                 </button>
                             </div>
                             
@@ -194,36 +175,6 @@
                     <p class="section-subtitle">Entdecken Sie weitere Produkte, die Ihnen gefallen könnten</p>
                 </div>
                 <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3 g-md-4">
-                <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-10.html'">
-                        <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 1">
-                        </div>
-                        <div class="product-info">
-                            <h5 class="product-title">Haushalt Produkt 1</h5>
-                            <div class="price-container"><span class="current-price">€15.00</span></div>
-                            <div class="view-product-btn">
-                                <span>Jetzt ansehen</span>
-                                <i class="bi bi-arrow-right"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-11.html'">
-                        <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 2">
-                        </div>
-                        <div class="product-info">
-                            <h5 class="product-title">Haushalt Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€18.00</span></div>
-                            <div class="view-product-btn">
-                                <span>Jetzt ansehen</span>
-                                <i class="bi bi-arrow-right"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
                 <div class="col">
                     <div class="similar-product-card" onclick="window.location.href='produkt-1.html'">
                         <div class="product-image-wrapper">
@@ -254,6 +205,36 @@
                         </div>
                     </div>
                 </div>
+                <div class="col">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-4.html'">
+                        <div class="product-image-wrapper">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Mode Produkt 1">
+                        </div>
+                        <div class="product-info">
+                            <h5 class="product-title">Mode Produkt 1</h5>
+                            <div class="price-container"><span class="current-price">€20.00</span></div>
+                            <div class="view-product-btn">
+                                <span>Jetzt ansehen</span>
+                                <i class="bi bi-arrow-right"></i>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-5.html'">
+                        <div class="product-image-wrapper">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Mode Produkt 2">
+                        </div>
+                        <div class="product-info">
+                            <h5 class="product-title">Mode Produkt 2</h5>
+                            <div class="price-container"><span class="current-price">€22.00</span></div>
+                            <div class="view-product-btn">
+                                <span>Jetzt ansehen</span>
+                                <i class="bi bi-arrow-right"></i>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 </div>
             </div>
         </section>
@@ -269,11 +250,11 @@
     <script>
   // Produktdaten für diese Seite
   const product = {
-    id: 12,
-    name: "Haushalt Produkt 3",
-    price: 44.00,
+    id: 3,
+    name: "Elektronik Produkt 3",
+    price: 14.00,
     image: "produkt bilder/ware.png",
-    description: "Praktisch und zuverlässig für Ihr Zuhause."
+    description: "Innovative Technologie für Ihren Alltag. Dieses hochwertige Produkt bietet die perfekte Balance zwischen Funktionalität und Design."
   };
 
   // Bundles dynamisch laden
@@ -282,12 +263,120 @@
     .then(products => {
       const prod = products.find(p => p.id === product.id);
       if (prod && prod.bundles && prod.bundles.length > 0) {
-        renderBundles(prod.bundles);
-      } else {
-        // Fallback: Bundle-Box immer anzeigen
         renderBundles();
       }
     });
+
+  function renderBundles() {
+    const einzelpreis = 14.00;
+    const staffel = [
+      {qty:1, price:einzelpreis, original:einzelpreis},
+      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
+      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
+    ];
+    const section = document.getElementById('bundle-section');
+    let selected = 1;
+    section.innerHTML = `
+      <div class="bundle-box">
+        <div class="bundle-header">BUNDLE & SPARE</div>
+        <form id="bundleForm">
+          ${staffel.map((s, i) => `
+            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
+              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
+              <div class="bundle-info">
+                <div class="bundle-title">
+                  ${s.qty} Set${s.qty>1?'s':''} kaufen
+                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
+                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
+                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
+                </div>
+                <div class="bundle-prices">
+                  €${s.price.toFixed(2)} pro Set
+                  <span class="old">€${s.original.toFixed(2)}</span>
+                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
+                </div>
+                ${s.qty>1?`<div style='margin-top:.7em;font-size:.97rem;'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
+              </div>
+            </div>
+          `).join('')}
+          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
+        </form>
+      </div>
+    `;
+    // Interaktive Auswahl
+    const cards = section.querySelectorAll('.bundle-card');
+    const radios = section.querySelectorAll('.bundle-radio');
+    
+    // Event-Listener für Radio-Buttons
+    radios.forEach((radio, i) => {
+      radio.addEventListener('change', () => {
+        cards.forEach(c => c.classList.remove('selected'));
+        cards[i].classList.add('selected');
+      });
+    });
+
+    // Event-Listener für Bundle-Cards
+    cards.forEach((card, i) => {
+      card.addEventListener('click', (e) => {
+        // Verhindere Bubbling wenn auf Radio geklickt wurde
+        if (e.target === radios[i]) return;
+        
+        // Wähle Radio-Button aus
+        radios[i].checked = true;
+        
+        // Aktualisiere Selected-Status
+        cards.forEach(c => c.classList.remove('selected'));
+        card.classList.add('selected');
+        
+        // Trigger change Event auf Radio
+        radios[i].dispatchEvent(new Event('change'));
+      });
+    });
+
+    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      const idx = Array.from(radios).findIndex(r => r.checked);
+      const s = staffel[idx];
+      addBundleToCart({
+        id: product.id,
+        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
+        price: s.price * s.qty, // Gesamtpreis für das Bundle
+        image: product.image,
+        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
+        bundleId: `${product.id}-qty${s.qty}`,
+        quantity: 1
+      });
+    });
+  }
+
+  function addBundleToCart(bundle) {
+    let cart = getCart();
+    // Bundle als eigenes Cart-Item mit bundleId
+    const bundleId = `${product.id}-${bundle.id}`;
+    const existing = cart.find(item => item.bundleId === bundleId);
+    if (existing) {
+      // Bei Bundles immer nur 1 erlauben
+      existing.quantity = 1;
+    } else {
+      cart.push({
+        id: product.id,
+        name: product.name + ' - ' + bundle.name,
+        price: bundle.price,
+        image: product.image,
+        description: product.description + ' (Bundle: ' + bundle.name + ')',
+        bundleId: bundleId,
+        bundleItems: bundle.items,
+        quantity: 1
+      });
+    }
+    setCart(cart);
+    // Popup anzeigen statt direkter Weiterleitung
+    if (typeof showAlert === 'function') {
+      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
+    } else {
+      showNotification('Bundle zum Warenkorb hinzugefügt');
+    }
+  }
 
   function getWishlist() {
     return JSON.parse(localStorage.getItem('wishlist')) || [];
@@ -342,15 +431,15 @@
             localStorage.setItem('cart', JSON.stringify(cart));
   }
   function addToCart(product) {
-      let cart = getCart();
-      const existing = cart.find(item => Number(item.id) === Number(product.id));
-      if (existing) {
-          existing.quantity += product.quantity || 1;
-      } else {
-          cart.push({ ...product, quantity: product.quantity || 1 });
-      }
-      setCart(cart);
-      // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
+    let cart = getCart();
+    const existing = cart.find(item => Number(item.id) === Number(product.id));
+    if (existing) {
+      existing.quantity += product.quantity || 1;
+    } else {
+      cart.push({ ...product, quantity: product.quantity || 1 });
+    }
+    setCart(cart);
+    // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
   }
   
   // showAlert function for cart popup
@@ -387,7 +476,7 @@
       }
     }, 1700);
   }
-
+  
   function showNotification(message, type = 'success') {
     const notification = document.createElement('div');
     notification.className = `alert alert-${type} position-fixed end-0 m-4 shadow-lg fade show`;
@@ -432,159 +521,45 @@
     }, 2000);
   }
 
-  function addBundleToCart(bundle) {
-    let cart = getCart();
-    const bundleId = bundle.bundleId;
-    const existing = cart.find(item => item.bundleId === bundleId);
-    if (existing) {
-        existing.quantity = 1;
-    } else {
-        cart.push({
-            id: product.id,
-            name: bundle.name,
-            price: bundle.price,
-            image: product.image,
-            description: bundle.description,
-            bundleId: bundleId,
-            bundleItems: [], // Keine Items für die neue Staffel
-            quantity: 1
-        });
-    }
-    setCart(cart);
-    // Popup anzeigen statt direkter Weiterleitung
-    if (typeof showAlert === 'function') {
-      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
-    } else {
-      showNotification('Bundle zum Warenkorb hinzugefügt');
-    }
-}
-
-  function renderBundles() {
-    const einzelpreis = 44.00;
-    const staffel = [
-      {qty:1, price:einzelpreis, original:einzelpreis},
-      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
-      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
-    ];
-    const section = document.getElementById('bundle-section');
-    let selected = 1;
-    section.innerHTML = `
-      <div class="bundle-box">
-        <div class="bundle-header">BUNDLE & SPARE</div>
-        <form id="bundleForm">
-          ${staffel.map((s, i) => `
-            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
-              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
-              <div class="bundle-info">
-                <div class="bundle-title">
-                  ${s.qty} Set${s.qty>1?'s':''} kaufen
-                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
-                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
-                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
-                </div>
-                <div class="bundle-prices">
-                  €${s.price.toFixed(2)} pro Set
-                  <span class="old">€${s.original.toFixed(2)}</span>
-                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
-                </div>
-                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
-              </div>
-            </div>
-          `).join('')}
-          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
-        </form>
-      </div>
-    `;
-    // Interaktive Auswahl
-    const cards = section.querySelectorAll('.bundle-card');
-    const radios = section.querySelectorAll('.bundle-radio');
-    
-    // Event-Listener für Radio-Buttons
-    radios.forEach((radio, i) => {
-      radio.addEventListener('change', () => {
-        cards.forEach(c => c.classList.remove('selected'));
-        cards[i].classList.add('selected');
-      });
-    });
-
-    // Event-Listener für Bundle-Cards
-    cards.forEach((card, i) => {
-      card.addEventListener('click', (e) => {
-        // Verhindere Bubbling wenn auf Radio geklickt wurde
-        if (e.target === radios[i]) return;
-        
-        // Wähle Radio-Button aus
-        radios[i].checked = true;
-        
-        // Aktualisiere Selected-Status
-        cards.forEach(c => c.classList.remove('selected'));
-        card.classList.add('selected');
-        
-        // Trigger change Event auf Radio
-        radios[i].dispatchEvent(new Event('change'));
-      });
-    });
-
-    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
-      e.preventDefault();
-      const idx = Array.from(radios).findIndex(r => r.checked);
-      const s = staffel[idx];
-      addBundleToCart({
-        id: product.id,
-        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
-        price: s.price * s.qty,
-        image: product.image,
-        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
-        bundleId: `${product.id}-qty${s.qty}`,
-        quantity: s.qty
-      });
-    });
-  }
-
-  renderBundles();
-
   // Funktionen für die neue Schnellbestellung
-  function increaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue < 10) {
-        input.value = currentValue + 1;
-        updateTotalPrice();
-      }
+  function increaseQuantity() {
+    const input = document.getElementById('quantity');
+    const currentValue = parseInt(input.value, 10) || 1;
+    if (currentValue < 10) {
+      input.value = currentValue + 1;
+      updateTotalPrice();
     }
   }
 
-  function decreaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue > 1) {
-        input.value = currentValue - 1;
-        updateTotalPrice();
-      }
+  function decreaseQuantity() {
+    const input = document.getElementById('quantity');
+    const currentValue = parseInt(input.value, 10) || 1;
+    if (currentValue > 1) {
+      input.value = currentValue - 1;
+      updateTotalPrice();
     }
   }
 
   function updateTotalPrice() {
     const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
     const total = (product.price * quantity).toFixed(2);
-    document.getElementById('totalPrice').textContent = `€${total}`;
+    document.getElementById('totalPrice').textContent = total;
   }
 
-
+  function addToCartWithQuantity() {
+    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
+    const productToCart = {
+      ...product,
+      quantity: quantity
+    };
+    addToCart(productToCart);
+    // Popup anzeigen statt direkter Weiterleitung
+    if (typeof showAlert === 'function') {
+      showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
+    } else {
+      showNotification('Zum Warenkorb hinzugefügt');
+    }
+  }
 
   document.addEventListener('DOMContentLoaded', function() {
     // Event-Listener für Hero-Buttons
@@ -594,21 +569,14 @@
     if (cartBtn) {
       cartBtn.addEventListener('click', function(e) {
         e.preventDefault();
-        addToCart({
-            id: product.id,
-            name: product.name,
-            price: product.price,
-            image: product.image,
-            description: product.description,
-            quantity: 1
-        });
+        addToCart(product);
         // Popup anzeigen statt direkter Weiterleitung
         if (typeof showAlert === 'function') {
           showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
         } else {
           showNotification('Zum Warenkorb hinzugefügt');
         }
-    });
+      });
     }
     
     if (wishlistBtn) {
@@ -621,30 +589,10 @@
 
     // Event-Listener für Quantity-Input
     const quantityInput = document.getElementById('quantity');
-    const buyNowBtn = document.getElementById('buyNowBtn');
-    
     if (quantityInput) {
       quantityInput.addEventListener('input', updateTotalPrice);
       quantityInput.addEventListener('change', updateTotalPrice);
       updateTotalPrice(); // Initialisiere den Preis
-    }
-    
-    if (buyNowBtn) {
-      buyNowBtn.addEventListener('click', function(e) {
-        e.preventDefault();
-        const quantity = parseInt(quantityInput.value, 10) || 1;
-        const productToCart = {
-          ...product,
-          quantity: quantity
-        };
-        addToCart(productToCart);
-        // Popup anzeigen statt direkter Weiterleitung
-        if (typeof showAlert === 'function') {
-          showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
-        } else {
-          showNotification('Zum Warenkorb hinzugefügt');
-        }
-      });
     }
   });
     </script>

--- a/produkte/produkt-4.html
+++ b/produkte/produkt-4.html
@@ -87,9 +87,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             
@@ -131,9 +131,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity-desktop" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             
@@ -526,8 +526,14 @@
     }, 2000);
   }
 
-  function addToCartWithQuantity() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
+  function addToCartWithQuantity(event) {
+    // Determine which quantity input to use based on the clicked button
+    const button = event ? event.target : null;
+    const isDesktop = button && button.closest('.d-none.d-lg-block');
+    
+    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
+    const quantityInput = document.getElementById(inputId);
+    const quantity = quantityInput ? parseInt(quantityInput.value, 10) || 1 : 1;
     const productToCart = {
       ...product,
       quantity: quantity

--- a/produkte/produkt-4.html.backup
+++ b/produkte/produkt-4.html.backup
@@ -3,33 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Haushalt Produkt 3 - Marktplatz</title>
+    <title>Mode Produkt 1 - Marktplatz</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <link href="haushalt.css" rel="stylesheet">
-    <style>
-        .product-hero {
-            background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
-            color: white;
-            padding: 4rem 0;
-        }
-        .product-image {
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-            transition: transform 0.3s ease;
-        }
-        .product-image:hover {
-            transform: scale(1.02);
-        }
-        .price-tag {
-            background: linear-gradient(45deg, #ff6b6b, #ee5a24);
-            color: white;
-            padding: 0.5rem 1.5rem;
-            border-radius: 25px;
-            font-weight: bold;
-            font-size: 1.5rem;
-        }
-    </style>
+    <link href="mode.css" rel="stylesheet">
 </head>
 <body>
     <!-- Navigation -->
@@ -54,21 +31,21 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-6">
-                    <h1 class="display-4 fw-bold mb-3">Haushalt Produkt 3</h1>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <h1 class="display-4 fw-bold mb-3">Mode Produkt 1</h1>
+                    <p class="lead mb-4">Beschreibungstext für Mode Produkt 1</p>
                     <div class="d-flex align-items-center gap-3 mb-4">
-                        <span class="price-tag">€44.00</span>
+                        <span class="price-tag">€20.00</span>
                         <span class="badge bg-success">Kostenloser Versand in Europa</span>
                     </div>
                     <button class="btn btn-light btn-lg me-3" id="cartBtn">
                         <i class="bi bi-cart-plus"></i> In den Warenkorb
                     </button>
                     <button class="btn btn-outline-light btn-lg" id="wishlistBtn">
-                        <i class="bi bi-heart"></i> Merken
+                        <i class="bi bi-heart"></i> Zur Wunschliste
                     </button>
                 </div>
                 <div class="col-lg-6 text-center">
-                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
+                    <img src="../produkt bilder/ware.png" alt="Mode Produkt 1" class="img-fluid product-image" style="max-height: 400px;">
                 </div>
             </div>
         </div>
@@ -80,19 +57,19 @@
             <div class="row">
                 <div class="col-lg-8">
                     <h2 class="mb-4">Produktbeschreibung</h2>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <p class="lead mb-4">Stylische Mode für jeden Anlass. Entdecken Sie zeitlose Eleganz und modernen Komfort in einem.</p>
                     
                     <h3>Hauptmerkmale</h3>
                     <ul class="list-unstyled">
-                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Robuste Konstruktion</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Einfache Bedienung</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Platzsparend</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Wartungsarm</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>3 Jahre Garantie</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Premium Qualität</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Bequemer Sitz</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Stylisch</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Langlebig</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Pflegeleicht</li>
                     </ul>
 
                     <h3 class="mt-4">Technische Spezifikationen</h3>
                     <div class="row">
                         <div class="col-md-6">
-                            <p><strong>Kategorie:</strong> Haushalt</p>
-                            <p><strong>Artikelnummer:</strong> 012</p>
-                            <p><strong>Preis:</strong> €44.00</p>
+                            <p><strong>Kategorie:</strong> Mode</p>
+                            <p><strong>Artikelnummer:</strong> 004</p>
+                            <p><strong>Preis:</strong> €20.00</p>
                         </div>
                         <div class="col-md-6">
                             <p><strong>Verfügbarkeit:</strong> Auf Lager</p>
@@ -110,23 +87,26 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
+                            
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€<span id="currentPrice">20.00</span></div>
+                                <div class="total-price">Gesamt: €<span id="totalPrice">20.00</span></div>
                             </div>
+                            
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
+                                <button class="buy-now-btn">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
                                     <i class="bi bi-heart"></i> Zur Wunschliste
                                 </button>
                             </div>
+                            
                             <div class="features-section">
                                 <ul class="features-list">
                                     <li><i class="bi bi-truck"></i> Kostenloser Versand in Europa</li>
@@ -142,6 +122,7 @@
                 </div>
                 
                 <div class="col-lg-4">
+                    <!-- Schnellbestellung (Desktop only) -->
                     <div class="quick-order-card d-none d-lg-block">
                         <div class="quick-order-header">
                             <h4>Schnellbestellung</h4>
@@ -150,23 +131,23 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
-                                    <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <input type="number" class="quantity-input" id="quantity-desktop" value="1" min="1" max="10">
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€<span id="currentPriceDesktop">20.00</span></div>
+                                <div class="total-price">Gesamt: €<span id="totalPriceDesktop">20.00</span></div>
                             </div>
                             
                             <div class="action-buttons">
-                                <button class="buy-now-btn" id="buyNowBtn">
+                                <button class="buy-now-btn">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
-                                    <i class="bi bi-heart"></i> Zur Wunschliste hinzufügen
+                                    <i class="bi bi-heart"></i> Zur Wunschliste
                                 </button>
                             </div>
                             
@@ -195,13 +176,13 @@
                 </div>
                 <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3 g-md-4">
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-10.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-5.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 1">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Mode Produkt 2">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Haushalt Produkt 1</h5>
-                            <div class="price-container"><span class="current-price">€15.00</span></div>
+                            <h5 class="product-title">Mode Produkt 2</h5>
+                            <div class="price-container"><span class="current-price">€22.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -210,13 +191,13 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-11.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-6.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 2">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Mode Produkt 3">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Haushalt Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€18.00</span></div>
+                            <h5 class="product-title">Mode Produkt 3</h5>
+                            <div class="price-container"><span class="current-price">€24.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -225,13 +206,13 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-1.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-7.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 1">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 1">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 1</h5>
-                            <div class="price-container"><span class="current-price">€10.00</span></div>
+                            <h5 class="product-title">Fitness Produkt 1</h5>
+                            <div class="price-container"><span class="current-price">€30.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -240,13 +221,13 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-2.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-8.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 2">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 2">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€12.00</span></div>
+                            <h5 class="product-title">Fitness Produkt 2</h5>
+                            <div class="price-container"><span class="current-price">€35.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -269,11 +250,11 @@
     <script>
   // Produktdaten für diese Seite
   const product = {
-    id: 12,
-    name: "Haushalt Produkt 3",
-    price: 44.00,
+    id: 4,
+    name: "Mode Produkt 1",
+    price: 20.00,
     image: "produkt bilder/ware.png",
-    description: "Praktisch und zuverlässig für Ihr Zuhause."
+    description: "Modisch und hochwertig für jeden Anlass. Dieses hochwertige Produkt bietet die perfekte Balance zwischen Funktionalität und Design."
   };
 
   // Bundles dynamisch laden
@@ -288,6 +269,119 @@
         renderBundles();
       }
     });
+
+  function renderBundles() {
+    const einzelpreis = 20.00;
+    const staffel = [
+      {qty:1, price:einzelpreis, original:einzelpreis},
+      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
+      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
+    ];
+    const section = document.getElementById('bundle-section');
+    let selected = 1;
+    section.innerHTML = `
+      <div class="bundle-box">
+        <div class="bundle-header">BUNDLE & SPARE</div>
+        <form id="bundleForm">
+          ${staffel.map((s, i) => `
+            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
+              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
+              <div class="bundle-info">
+                <div class="bundle-title">
+                  ${s.qty} Set${s.qty>1?'s':''} kaufen
+                </div>
+                <div class="bundle-badges">
+                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
+                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
+                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
+                </div>
+                <div class="bundle-prices">
+                  €${s.price.toFixed(2)} pro Set
+                  <span class="old">€${s.original.toFixed(2)}</span>
+                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
+                </div>
+                ${s.qty>1?`<div style='margin-top:.7em;font-size:.97rem;'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
+              </div>
+            </div>
+          `).join('')}
+          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
+        </form>
+      </div>
+    `;
+    // Interaktive Auswahl
+    const cards = section.querySelectorAll('.bundle-card');
+    const radios = section.querySelectorAll('.bundle-radio');
+    
+    // Event-Listener für Radio-Buttons
+    radios.forEach((radio, i) => {
+      radio.addEventListener('change', () => {
+        cards.forEach(c => c.classList.remove('selected'));
+        cards[i].classList.add('selected');
+      });
+    });
+
+    // Event-Listener für Bundle-Cards
+    cards.forEach((card, i) => {
+      card.addEventListener('click', (e) => {
+        // Verhindere Bubbling wenn auf Radio geklickt wurde
+        if (e.target === radios[i]) return;
+        
+        // Wähle Radio-Button aus
+        radios[i].checked = true;
+        
+        // Aktualisiere Selected-Status
+        cards.forEach(c => c.classList.remove('selected'));
+        card.classList.add('selected');
+        
+        // Trigger change Event auf Radio
+        radios[i].dispatchEvent(new Event('change'));
+      });
+    });
+
+    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      const idx = Array.from(radios).findIndex(r => r.checked);
+      const s = staffel[idx];
+      addBundleToCart({
+        id: product.id,
+        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
+        price: s.price * s.qty, // Gesamtpreis für das Bundle
+        image: product.image,
+        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
+        bundleId: `${product.id}-qty${s.qty}`,
+        quantity: 1
+      });
+    });
+  }
+
+  function addBundleToCart(bundle) {
+    let cart = getCart();
+    // Bundle als eigenes Cart-Item mit bundleId
+    const bundleId = `${product.id}-${bundle.id}`;
+    const existing = cart.find(item => item.bundleId === bundleId);
+    if (existing) {
+      // Bei Bundles immer nur 1 erlauben
+      existing.quantity = 1;
+    } else {
+      cart.push({
+        id: product.id,
+        name: product.name + ' - ' + bundle.name,
+        price: bundle.price,
+        image: product.image,
+        description: product.description + ' (Bundle: ' + bundle.name + ')',
+        bundleId: bundleId,
+        bundleItems: bundle.items,
+        quantity: 1
+      });
+    }
+    setCart(cart);
+    // Popup anzeigen statt direkter Weiterleitung
+    if (typeof showAlert === 'function') {
+      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
+    } else {
+      showNotification('Bundle zum Warenkorb hinzugefügt');
+    }
+  }
 
   function getWishlist() {
     return JSON.parse(localStorage.getItem('wishlist')) || [];
@@ -342,15 +436,15 @@
             localStorage.setItem('cart', JSON.stringify(cart));
   }
   function addToCart(product) {
-      let cart = getCart();
-      const existing = cart.find(item => Number(item.id) === Number(product.id));
-      if (existing) {
-          existing.quantity += product.quantity || 1;
-      } else {
-          cart.push({ ...product, quantity: product.quantity || 1 });
-      }
-      setCart(cart);
-      // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
+    let cart = getCart();
+    const existing = cart.find(item => Number(item.id) === Number(product.id));
+    if (existing) {
+      existing.quantity += product.quantity || 1;
+    } else {
+      cart.push({ ...product, quantity: product.quantity || 1 });
+    }
+        setCart(cart);
+    // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
   }
   
   // showAlert function for cart popup
@@ -387,7 +481,7 @@
       }
     }, 1700);
   }
-
+  
   function showNotification(message, type = 'success') {
     const notification = document.createElement('div');
     notification.className = `alert alert-${type} position-fixed end-0 m-4 shadow-lg fade show`;
@@ -432,185 +526,67 @@
     }, 2000);
   }
 
-  function addBundleToCart(bundle) {
-    let cart = getCart();
-    const bundleId = bundle.bundleId;
-    const existing = cart.find(item => item.bundleId === bundleId);
-    if (existing) {
-        existing.quantity = 1;
-    } else {
-        cart.push({
-            id: product.id,
-            name: bundle.name,
-            price: bundle.price,
-            image: product.image,
-            description: bundle.description,
-            bundleId: bundleId,
-            bundleItems: [], // Keine Items für die neue Staffel
-            quantity: 1
-        });
-    }
-    setCart(cart);
+  function addToCartWithQuantity() {
+    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
+    const productToCart = {
+      ...product,
+      quantity: quantity
+    };
+    addToCart(productToCart);
     // Popup anzeigen statt direkter Weiterleitung
     if (typeof showAlert === 'function') {
-      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
+      showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
     } else {
-      showNotification('Bundle zum Warenkorb hinzugefügt');
-    }
-}
-
-  function renderBundles() {
-    const einzelpreis = 44.00;
-    const staffel = [
-      {qty:1, price:einzelpreis, original:einzelpreis},
-      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
-      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
-    ];
-    const section = document.getElementById('bundle-section');
-    let selected = 1;
-    section.innerHTML = `
-      <div class="bundle-box">
-        <div class="bundle-header">BUNDLE & SPARE</div>
-        <form id="bundleForm">
-          ${staffel.map((s, i) => `
-            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
-              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
-              <div class="bundle-info">
-                <div class="bundle-title">
-                  ${s.qty} Set${s.qty>1?'s':''} kaufen
-                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
-                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
-                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
-                </div>
-                <div class="bundle-prices">
-                  €${s.price.toFixed(2)} pro Set
-                  <span class="old">€${s.original.toFixed(2)}</span>
-                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
-                </div>
-                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
-              </div>
-            </div>
-          `).join('')}
-          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
-        </form>
-      </div>
-    `;
-    // Interaktive Auswahl
-    const cards = section.querySelectorAll('.bundle-card');
-    const radios = section.querySelectorAll('.bundle-radio');
-    
-    // Event-Listener für Radio-Buttons
-    radios.forEach((radio, i) => {
-      radio.addEventListener('change', () => {
-        cards.forEach(c => c.classList.remove('selected'));
-        cards[i].classList.add('selected');
-      });
-    });
-
-    // Event-Listener für Bundle-Cards
-    cards.forEach((card, i) => {
-      card.addEventListener('click', (e) => {
-        // Verhindere Bubbling wenn auf Radio geklickt wurde
-        if (e.target === radios[i]) return;
-        
-        // Wähle Radio-Button aus
-        radios[i].checked = true;
-        
-        // Aktualisiere Selected-Status
-        cards.forEach(c => c.classList.remove('selected'));
-        card.classList.add('selected');
-        
-        // Trigger change Event auf Radio
-        radios[i].dispatchEvent(new Event('change'));
-      });
-    });
-
-    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
-      e.preventDefault();
-      const idx = Array.from(radios).findIndex(r => r.checked);
-      const s = staffel[idx];
-      addBundleToCart({
-        id: product.id,
-        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
-        price: s.price * s.qty,
-        image: product.image,
-        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
-        bundleId: `${product.id}-qty${s.qty}`,
-        quantity: s.qty
-      });
-    });
-  }
-
-  renderBundles();
-
-  // Funktionen für die neue Schnellbestellung
-  function increaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue < 10) {
-        input.value = currentValue + 1;
-        updateTotalPrice();
-      }
+      showNotification('Zum Warenkorb hinzugefügt');
     }
   }
 
-  function decreaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue > 1) {
-        input.value = currentValue - 1;
-        updateTotalPrice();
-      }
+  // Mengenfunktionen für Schnellbestellung
+  function decreaseQuantity() {
+    const quantityInput = document.getElementById('quantity');
+    const currentValue = parseInt(quantityInput.value, 10) || 1;
+    if (currentValue > 1) {
+      quantityInput.value = currentValue - 1;
+      updatePrices();
     }
   }
 
-  function updateTotalPrice() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
-    const total = (product.price * quantity).toFixed(2);
-    document.getElementById('totalPrice').textContent = `€${total}`;
+  function increaseQuantity() {
+    const quantityInput = document.getElementById('quantity');
+    const currentValue = parseInt(quantityInput.value, 10) || 1;
+    if (currentValue < 10) {
+      quantityInput.value = currentValue + 1;
+      updatePrices();
+    }
   }
 
-
+  function updatePrices() {
+    const quantityInput = document.getElementById('quantity');
+    const currentPriceSpan = document.getElementById('currentPrice');
+    const totalPriceSpan = document.getElementById('totalPrice');
+    const buyBtn = document.querySelector('.buy-now-btn');
+    
+    const qty = parseInt(quantityInput.value, 10) || 1;
+    const total = (product.price * qty).toFixed(2);
+    
+    if (currentPriceSpan) currentPriceSpan.textContent = product.price.toFixed(2);
+    if (totalPriceSpan) totalPriceSpan.textContent = total;
+    if (buyBtn) {
+      buyBtn.innerHTML = `<i class="bi bi-cart-plus"></i> Jetzt kaufen - €${total}`;
+    }
+  }
 
   document.addEventListener('DOMContentLoaded', function() {
-    // Event-Listener für Hero-Buttons
-    const cartBtn = document.getElementById('cartBtn');
-    const wishlistBtn = document.getElementById('wishlistBtn');
-    
-    if (cartBtn) {
-      cartBtn.addEventListener('click', function(e) {
-        e.preventDefault();
-        addToCart({
-            id: product.id,
-            name: product.name,
-            price: product.price,
-            image: product.image,
-            description: product.description,
-            quantity: 1
-        });
-        // Popup anzeigen statt direkter Weiterleitung
-        if (typeof showAlert === 'function') {
-          showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
-        } else {
-          showNotification('Zum Warenkorb hinzugefügt');
-        }
-    });
+    let wishlistBtn = document.getElementById('wishlistBtn');
+    if (!wishlistBtn) {
+      const hero = document.querySelector('.product-hero .col-lg-6');
+      if (hero) {
+        wishlistBtn = document.createElement('button');
+        wishlistBtn.id = 'wishlistBtn';
+        wishlistBtn.className = 'btn btn-outline-light btn-lg ms-2';
+        hero.appendChild(wishlistBtn);
+      }
     }
-    
     if (wishlistBtn) {
       wishlistBtn.addEventListener('click', function(e) {
         e.preventDefault();
@@ -618,24 +594,35 @@
       });
       updateWishlistButton();
     }
-
-    // Event-Listener für Quantity-Input
-    const quantityInput = document.getElementById('quantity');
-    const buyNowBtn = document.getElementById('buyNowBtn');
-    
-    if (quantityInput) {
-      quantityInput.addEventListener('input', updateTotalPrice);
-      quantityInput.addEventListener('change', updateTotalPrice);
-      updateTotalPrice(); // Initialisiere den Preis
+    let cartBtn = document.getElementById('cartBtn');
+    if (cartBtn) {
+      cartBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        addToCart(product);
+        // Popup anzeigen statt direkter Weiterleitung
+        if (typeof showAlert === 'function') {
+          showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
+        } else {
+          showNotification('Zum Warenkorb hinzugefügt');
+        }
+      });
     }
     
-    if (buyNowBtn) {
-      buyNowBtn.addEventListener('click', function(e) {
+    // Dynamischer Preis für Schnellbestellung
+    const quantityInput = document.getElementById('quantity');
+    const buyBtn = document.querySelector('.buy-now-btn');
+    
+    if (quantityInput && buyBtn) {
+      quantityInput.addEventListener('input', updatePrices);
+      quantityInput.addEventListener('change', updatePrices);
+      updatePrices();
+      
+      buyBtn.addEventListener('click', function(e) {
         e.preventDefault();
-        const quantity = parseInt(quantityInput.value, 10) || 1;
+        const qty = parseInt(quantityInput.value, 10) || 1;
         const productToCart = {
           ...product,
-          quantity: quantity
+          quantity: qty
         };
         addToCart(productToCart);
         // Popup anzeigen statt direkter Weiterleitung

--- a/produkte/produkt-5.html
+++ b/produkte/produkt-5.html
@@ -87,9 +87,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             
@@ -131,9 +131,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity-desktop" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             

--- a/produkte/produkt-5.html.backup
+++ b/produkte/produkt-5.html.backup
@@ -3,33 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Haushalt Produkt 3 - Marktplatz</title>
+    <title>Mode Produkt 2 - Marktplatz</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <link href="haushalt.css" rel="stylesheet">
-    <style>
-        .product-hero {
-            background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
-            color: white;
-            padding: 4rem 0;
-        }
-        .product-image {
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-            transition: transform 0.3s ease;
-        }
-        .product-image:hover {
-            transform: scale(1.02);
-        }
-        .price-tag {
-            background: linear-gradient(45deg, #ff6b6b, #ee5a24);
-            color: white;
-            padding: 0.5rem 1.5rem;
-            border-radius: 25px;
-            font-weight: bold;
-            font-size: 1.5rem;
-        }
-    </style>
+    <link href="mode.css" rel="stylesheet">
 </head>
 <body>
     <!-- Navigation -->
@@ -54,21 +31,21 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-6">
-                    <h1 class="display-4 fw-bold mb-3">Haushalt Produkt 3</h1>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <h1 class="display-4 fw-bold mb-3">Mode Produkt 2</h1>
+                    <p class="lead mb-4">Beschreibungstext für Mode Produkt 2</p>
                     <div class="d-flex align-items-center gap-3 mb-4">
-                        <span class="price-tag">€44.00</span>
+                        <span class="price-tag">€22.00</span>
                         <span class="badge bg-success">Kostenloser Versand in Europa</span>
                     </div>
                     <button class="btn btn-light btn-lg me-3" id="cartBtn">
                         <i class="bi bi-cart-plus"></i> In den Warenkorb
                     </button>
                     <button class="btn btn-outline-light btn-lg" id="wishlistBtn">
-                        <i class="bi bi-heart"></i> Merken
+                        <i class="bi bi-heart"></i> Zur Wunschliste
                     </button>
                 </div>
                 <div class="col-lg-6 text-center">
-                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
+                    <img src="../produkt bilder/ware.png" alt="Mode Produkt 2" class="img-fluid product-image" style="max-height: 400px;">
                 </div>
             </div>
         </div>
@@ -80,19 +57,19 @@
             <div class="row">
                 <div class="col-lg-8">
                     <h2 class="mb-4">Produktbeschreibung</h2>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <p class="lead mb-4">Stylische Mode für jeden Anlass. Entdecken Sie zeitlose Eleganz und modernen Komfort in einem.</p>
                     
                     <h3>Hauptmerkmale</h3>
                     <ul class="list-unstyled">
-                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Robuste Konstruktion</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Einfache Bedienung</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Platzsparend</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Wartungsarm</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>3 Jahre Garantie</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Premium Qualität</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Bequemer Sitz</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Stylisch</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Langlebig</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Pflegeleicht</li>
                     </ul>
 
                     <h3 class="mt-4">Technische Spezifikationen</h3>
                     <div class="row">
                         <div class="col-md-6">
-                            <p><strong>Kategorie:</strong> Haushalt</p>
-                            <p><strong>Artikelnummer:</strong> 012</p>
-                            <p><strong>Preis:</strong> €44.00</p>
+                            <p><strong>Kategorie:</strong> Mode</p>
+                            <p><strong>Artikelnummer:</strong> 005</p>
+                            <p><strong>Preis:</strong> €22.00</p>
                         </div>
                         <div class="col-md-6">
                             <p><strong>Verfügbarkeit:</strong> Auf Lager</p>
@@ -110,23 +87,26 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
+                            
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€<span id="currentPrice">22.00</span></div>
+                                <div class="total-price">Gesamt: €<span id="totalPrice">22.00</span></div>
                             </div>
+                            
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
+                                <button class="buy-now-btn" id="buyNowBtn">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
                                     <i class="bi bi-heart"></i> Zur Wunschliste
                                 </button>
                             </div>
+                            
                             <div class="features-section">
                                 <ul class="features-list">
                                     <li><i class="bi bi-truck"></i> Kostenloser Versand in Europa</li>
@@ -142,6 +122,7 @@
                 </div>
                 
                 <div class="col-lg-4">
+                    <!-- Schnellbestellung (Desktop only) -->
                     <div class="quick-order-card d-none d-lg-block">
                         <div class="quick-order-header">
                             <h4>Schnellbestellung</h4>
@@ -150,23 +131,23 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
-                                    <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <input type="number" class="quantity-input" id="quantity-desktop" value="1" min="1" max="10">
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€<span id="currentPriceDesktop">22.00</span></div>
+                                <div class="total-price">Gesamt: €<span id="totalPriceDesktop">22.00</span></div>
                             </div>
                             
                             <div class="action-buttons">
-                                <button class="buy-now-btn" id="buyNowBtn">
+                                <button class="buy-now-btn" id="buyNowBtnDesktop">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
-                                    <i class="bi bi-heart"></i> Zur Wunschliste hinzufügen
+                                    <i class="bi bi-heart"></i> Zur Wunschliste
                                 </button>
                             </div>
                             
@@ -195,13 +176,13 @@
                 </div>
                 <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3 g-md-4">
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-10.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-4.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 1">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Mode Produkt 1">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Haushalt Produkt 1</h5>
-                            <div class="price-container"><span class="current-price">€15.00</span></div>
+                            <h5 class="product-title">Mode Produkt 1</h5>
+                            <div class="price-container"><span class="current-price">€20.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -210,13 +191,13 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-11.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-6.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 2">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Mode Produkt 3">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Haushalt Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€18.00</span></div>
+                            <h5 class="product-title">Mode Produkt 3</h5>
+                            <div class="price-container"><span class="current-price">€24.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -225,13 +206,13 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-1.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-7.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 1">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 1">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 1</h5>
-                            <div class="price-container"><span class="current-price">€10.00</span></div>
+                            <h5 class="product-title">Fitness Produkt 1</h5>
+                            <div class="price-container"><span class="current-price">€30.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -240,13 +221,13 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-2.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-8.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 2">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 2">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€12.00</span></div>
+                            <h5 class="product-title">Fitness Produkt 2</h5>
+                            <div class="price-container"><span class="current-price">€35.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -269,11 +250,11 @@
     <script>
   // Produktdaten für diese Seite
   const product = {
-    id: 12,
-    name: "Haushalt Produkt 3",
-    price: 44.00,
+    id: 5,
+    name: "Mode Produkt 2",
+    price: 22.00,
     image: "produkt bilder/ware.png",
-    description: "Praktisch und zuverlässig für Ihr Zuhause."
+    description: "Modisch und hochwertig für jeden Anlass. Dieses hochwertige Produkt bietet die perfekte Balance zwischen Funktionalität und Design."
   };
 
   // Bundles dynamisch laden
@@ -283,11 +264,121 @@
       const prod = products.find(p => p.id === product.id);
       if (prod && prod.bundles && prod.bundles.length > 0) {
         renderBundles(prod.bundles);
-      } else {
-        // Fallback: Bundle-Box immer anzeigen
-        renderBundles();
       }
     });
+
+  function renderBundles() {
+    const einzelpreis = 22.00;
+    const staffel = [
+      {qty:1, price:einzelpreis, original:einzelpreis},
+      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
+      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
+    ];
+    const section = document.getElementById('bundle-section');
+    let selected = 1;
+    section.innerHTML = `
+      <div class="bundle-box">
+        <div class="bundle-header">BUNDLE & SPARE</div>
+        <form id="bundleForm">
+          ${staffel.map((s, i) => `
+            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
+              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
+              <div class="bundle-info">
+                <div class="bundle-title">
+                  ${s.qty} Set${s.qty>1?'s':''} kaufen
+                </div>
+                <div class="bundle-badges">
+                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
+                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
+                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
+                </div>
+                <div class="bundle-prices">
+                  €${s.price.toFixed(2)} pro Set
+                  <span class="old">€${s.original.toFixed(2)}</span>
+                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
+                </div>
+                ${s.qty>1?`<div style='margin-top:.7em;font-size:.97rem;'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
+              </div>
+            </div>
+          `).join('')}
+          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
+        </form>
+      </div>
+    `;
+    // Interaktive Auswahl
+    const cards = section.querySelectorAll('.bundle-card');
+    const radios = section.querySelectorAll('.bundle-radio');
+    
+    // Event-Listener für Radio-Buttons
+    radios.forEach((radio, i) => {
+      radio.addEventListener('change', () => {
+        cards.forEach(c => c.classList.remove('selected'));
+        cards[i].classList.add('selected');
+      });
+    });
+
+    // Event-Listener für Bundle-Cards
+    cards.forEach((card, i) => {
+      card.addEventListener('click', (e) => {
+        // Verhindere Bubbling wenn auf Radio geklickt wurde
+        if (e.target === radios[i]) return;
+        
+        // Wähle Radio-Button aus
+        radios[i].checked = true;
+        
+        // Aktualisiere Selected-Status
+        cards.forEach(c => c.classList.remove('selected'));
+        card.classList.add('selected');
+        
+        // Trigger change Event auf Radio
+        radios[i].dispatchEvent(new Event('change'));
+      });
+    });
+
+    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      const idx = Array.from(radios).findIndex(r => r.checked);
+      const s = staffel[idx];
+      addBundleToCart({
+        id: product.id,
+        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
+        price: s.price * s.qty, // Gesamtpreis für das Bundle
+        image: product.image,
+        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
+        bundleId: `${product.id}-qty${s.qty}`,
+        quantity: 1
+      });
+    });
+  }
+
+  function addBundleToCart(bundle) {
+    let cart = getCart();
+    // Bundle als eigenes Cart-Item mit bundleId
+    const bundleId = `${product.id}-${bundle.id}`;
+    const existing = cart.find(item => item.bundleId === bundleId);
+    if (existing) {
+      // Bei Bundles immer nur 1 erlauben
+      existing.quantity = 1;
+    } else {
+      cart.push({
+        id: product.id,
+        name: product.name + ' - ' + bundle.name,
+        price: bundle.price,
+        image: product.image,
+        description: product.description + ' (Bundle: ' + bundle.name + ')',
+        bundleId: bundleId,
+        bundleItems: bundle.items,
+        quantity: 1
+      });
+    }
+    setCart(cart);
+    // Popup anzeigen statt direkter Weiterleitung
+    if (typeof showAlert === 'function') {
+      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
+    } else {
+      showNotification('Bundle zum Warenkorb hinzugefügt');
+    }
+  }
 
   function getWishlist() {
     return JSON.parse(localStorage.getItem('wishlist')) || [];
@@ -342,15 +433,15 @@
             localStorage.setItem('cart', JSON.stringify(cart));
   }
   function addToCart(product) {
-      let cart = getCart();
-      const existing = cart.find(item => Number(item.id) === Number(product.id));
-      if (existing) {
-          existing.quantity += product.quantity || 1;
-      } else {
-          cart.push({ ...product, quantity: product.quantity || 1 });
-      }
-      setCart(cart);
-      // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
+    let cart = getCart();
+    const existing = cart.find(item => Number(item.id) === Number(product.id));
+    if (existing) {
+      existing.quantity += product.quantity || 1;
+    } else {
+      cart.push({ ...product, quantity: product.quantity || 1 });
+    }
+    setCart(cart);
+    // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
   }
   
   // showAlert function for cart popup
@@ -387,7 +478,7 @@
       }
     }, 1700);
   }
-
+  
   function showNotification(message, type = 'success') {
     const notification = document.createElement('div');
     notification.className = `alert alert-${type} position-fixed end-0 m-4 shadow-lg fade show`;
@@ -432,185 +523,52 @@
     }, 2000);
   }
 
-  function addBundleToCart(bundle) {
-    let cart = getCart();
-    const bundleId = bundle.bundleId;
-    const existing = cart.find(item => item.bundleId === bundleId);
-    if (existing) {
-        existing.quantity = 1;
-    } else {
-        cart.push({
-            id: product.id,
-            name: bundle.name,
-            price: bundle.price,
-            image: product.image,
-            description: bundle.description,
-            bundleId: bundleId,
-            bundleItems: [], // Keine Items für die neue Staffel
-            quantity: 1
-        });
-    }
-    setCart(cart);
-    // Popup anzeigen statt direkter Weiterleitung
-    if (typeof showAlert === 'function') {
-      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
-    } else {
-      showNotification('Bundle zum Warenkorb hinzugefügt');
-    }
-}
-
-  function renderBundles() {
-    const einzelpreis = 44.00;
-    const staffel = [
-      {qty:1, price:einzelpreis, original:einzelpreis},
-      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
-      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
-    ];
-    const section = document.getElementById('bundle-section');
-    let selected = 1;
-    section.innerHTML = `
-      <div class="bundle-box">
-        <div class="bundle-header">BUNDLE & SPARE</div>
-        <form id="bundleForm">
-          ${staffel.map((s, i) => `
-            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
-              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
-              <div class="bundle-info">
-                <div class="bundle-title">
-                  ${s.qty} Set${s.qty>1?'s':''} kaufen
-                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
-                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
-                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
-                </div>
-                <div class="bundle-prices">
-                  €${s.price.toFixed(2)} pro Set
-                  <span class="old">€${s.original.toFixed(2)}</span>
-                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
-                </div>
-                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
-              </div>
-            </div>
-          `).join('')}
-          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
-        </form>
-      </div>
-    `;
-    // Interaktive Auswahl
-    const cards = section.querySelectorAll('.bundle-card');
-    const radios = section.querySelectorAll('.bundle-radio');
-    
-    // Event-Listener für Radio-Buttons
-    radios.forEach((radio, i) => {
-      radio.addEventListener('change', () => {
-        cards.forEach(c => c.classList.remove('selected'));
-        cards[i].classList.add('selected');
-      });
-    });
-
-    // Event-Listener für Bundle-Cards
-    cards.forEach((card, i) => {
-      card.addEventListener('click', (e) => {
-        // Verhindere Bubbling wenn auf Radio geklickt wurde
-        if (e.target === radios[i]) return;
-        
-        // Wähle Radio-Button aus
-        radios[i].checked = true;
-        
-        // Aktualisiere Selected-Status
-        cards.forEach(c => c.classList.remove('selected'));
-        card.classList.add('selected');
-        
-        // Trigger change Event auf Radio
-        radios[i].dispatchEvent(new Event('change'));
-      });
-    });
-
-    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
-      e.preventDefault();
-      const idx = Array.from(radios).findIndex(r => r.checked);
-      const s = staffel[idx];
-      addBundleToCart({
-        id: product.id,
-        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
-        price: s.price * s.qty,
-        image: product.image,
-        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
-        bundleId: `${product.id}-qty${s.qty}`,
-        quantity: s.qty
-      });
-    });
-  }
-
-  renderBundles();
-
-  // Funktionen für die neue Schnellbestellung
-  function increaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue < 10) {
-        input.value = currentValue + 1;
-        updateTotalPrice();
-      }
+  // Mengenfunktionen für Schnellbestellung
+  function decreaseQuantity() {
+    const quantityInput = document.getElementById('quantity');
+    const currentValue = parseInt(quantityInput.value, 10) || 1;
+    if (currentValue > 1) {
+      quantityInput.value = currentValue - 1;
+      updatePrices();
     }
   }
 
-  function decreaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue > 1) {
-        input.value = currentValue - 1;
-        updateTotalPrice();
-      }
+  function increaseQuantity() {
+    const quantityInput = document.getElementById('quantity');
+    const currentValue = parseInt(quantityInput.value, 10) || 1;
+    if (currentValue < 10) {
+      quantityInput.value = currentValue + 1;
+      updatePrices();
     }
   }
 
-  function updateTotalPrice() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
-    const total = (product.price * quantity).toFixed(2);
-    document.getElementById('totalPrice').textContent = `€${total}`;
+  function updatePrices() {
+    const quantityInput = document.getElementById('quantity');
+    const currentPriceSpan = document.getElementById('currentPrice');
+    const totalPriceSpan = document.getElementById('totalPrice');
+    const buyBtn = document.querySelector('.buy-now-btn');
+    
+    const qty = parseInt(quantityInput.value, 10) || 1;
+    const total = (product.price * qty).toFixed(2);
+    
+    if (currentPriceSpan) currentPriceSpan.textContent = product.price.toFixed(2);
+    if (totalPriceSpan) totalPriceSpan.textContent = total;
+    if (buyBtn) {
+      buyBtn.innerHTML = `<i class="bi bi-cart-plus"></i> Jetzt kaufen - €${total}`;
+    }
   }
-
-
 
   document.addEventListener('DOMContentLoaded', function() {
-    // Event-Listener für Hero-Buttons
-    const cartBtn = document.getElementById('cartBtn');
-    const wishlistBtn = document.getElementById('wishlistBtn');
-    
-    if (cartBtn) {
-      cartBtn.addEventListener('click', function(e) {
-        e.preventDefault();
-        addToCart({
-            id: product.id,
-            name: product.name,
-            price: product.price,
-            image: product.image,
-            description: product.description,
-            quantity: 1
-        });
-        // Popup anzeigen statt direkter Weiterleitung
-        if (typeof showAlert === 'function') {
-          showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
-        } else {
-          showNotification('Zum Warenkorb hinzugefügt');
-        }
-    });
+    let wishlistBtn = document.getElementById('wishlistBtn');
+    if (!wishlistBtn) {
+      const hero = document.querySelector('.product-hero .col-lg-6');
+      if (hero) {
+        wishlistBtn = document.createElement('button');
+        wishlistBtn.id = 'wishlistBtn';
+        wishlistBtn.className = 'btn btn-outline-light btn-lg ms-2';
+        hero.appendChild(wishlistBtn);
+      }
     }
-    
     if (wishlistBtn) {
       wishlistBtn.addEventListener('click', function(e) {
         e.preventDefault();
@@ -618,24 +576,55 @@
       });
       updateWishlistButton();
     }
-
-    // Event-Listener für Quantity-Input
-    const quantityInput = document.getElementById('quantity');
-    const buyNowBtn = document.getElementById('buyNowBtn');
-    
-    if (quantityInput) {
-      quantityInput.addEventListener('input', updateTotalPrice);
-      quantityInput.addEventListener('change', updateTotalPrice);
-      updateTotalPrice(); // Initialisiere den Preis
+    let cartBtn = document.getElementById('cartBtn');
+    if (!cartBtn) {
+      const hero = document.querySelector('.product-hero .col-lg-6');
+      if (hero) {
+        cartBtn = document.createElement('button');
+        cartBtn.id = 'cartBtn';
+        cartBtn.className = 'btn btn-light btn-lg me-3';
+        hero.appendChild(cartBtn);
+      }
     }
-    
-    if (buyNowBtn) {
-      buyNowBtn.addEventListener('click', function(e) {
+    if (cartBtn) {
+      cartBtn.addEventListener('click', function(e) {
         e.preventDefault();
-        const quantity = parseInt(quantityInput.value, 10) || 1;
         const productToCart = {
-          ...product,
-          quantity: quantity
+          id: product.id,
+          name: product.name,
+          price: product.price,
+          image: product.image,
+          description: product.description,
+          quantity: 1
+        };
+        addToCart(productToCart);
+        // Popup anzeigen statt direkter Weiterleitung
+        if (typeof showAlert === 'function') {
+          showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
+        } else {
+          showNotification('Zum Warenkorb hinzugefügt');
+        }
+      });
+    }
+    // Dynamischer Preis für Schnellbestellung
+    const quantityInput = document.getElementById('quantity');
+    const buyBtn = document.querySelector('.buy-now-btn');
+    
+    if (quantityInput && buyBtn) {
+      quantityInput.addEventListener('input', updatePrices);
+      quantityInput.addEventListener('change', updatePrices);
+      updatePrices();
+      
+      buyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        const qty = parseInt(quantityInput.value, 10) || 1;
+        const productToCart = {
+          id: product.id,
+          name: product.name,
+          price: product.price,
+          image: product.image,
+          description: product.description,
+          quantity: qty
         };
         addToCart(productToCart);
         // Popup anzeigen statt direkter Weiterleitung

--- a/produkte/produkt-6.html
+++ b/produkte/produkt-6.html
@@ -87,9 +87,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
@@ -97,7 +97,7 @@
                                 <div class="total-price">Gesamt: <span id="totalPrice">€24.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -127,9 +127,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity-desktop" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             

--- a/produkte/produkt-6.html.backup
+++ b/produkte/produkt-6.html.backup
@@ -3,33 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Haushalt Produkt 3 - Marktplatz</title>
+    <title>Mode Produkt 3 - Marktplatz</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <link href="haushalt.css" rel="stylesheet">
-    <style>
-        .product-hero {
-            background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
-            color: white;
-            padding: 4rem 0;
-        }
-        .product-image {
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-            transition: transform 0.3s ease;
-        }
-        .product-image:hover {
-            transform: scale(1.02);
-        }
-        .price-tag {
-            background: linear-gradient(45deg, #ff6b6b, #ee5a24);
-            color: white;
-            padding: 0.5rem 1.5rem;
-            border-radius: 25px;
-            font-weight: bold;
-            font-size: 1.5rem;
-        }
-    </style>
+    <link href="mode.css" rel="stylesheet">
 </head>
 <body>
     <!-- Navigation -->
@@ -54,21 +31,21 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-6">
-                    <h1 class="display-4 fw-bold mb-3">Haushalt Produkt 3</h1>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <h1 class="display-4 fw-bold mb-3">Mode Produkt 3</h1>
+                    <p class="lead mb-4">Beschreibungstext für Mode Produkt 3</p>
                     <div class="d-flex align-items-center gap-3 mb-4">
-                        <span class="price-tag">€44.00</span>
+                        <span class="price-tag">€24.00</span>
                         <span class="badge bg-success">Kostenloser Versand in Europa</span>
                     </div>
-                    <button class="btn btn-light btn-lg me-3" id="cartBtn">
+                    <button class="btn btn-light btn-lg me-3" id="heroCartBtn">
                         <i class="bi bi-cart-plus"></i> In den Warenkorb
                     </button>
                     <button class="btn btn-outline-light btn-lg" id="wishlistBtn">
-                        <i class="bi bi-heart"></i> Merken
+                        <i class="bi bi-heart"></i> Zur Wunschliste
                     </button>
                 </div>
                 <div class="col-lg-6 text-center">
-                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
+                    <img src="../produkt bilder/ware.png" alt="Mode Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
                 </div>
             </div>
         </div>
@@ -80,19 +57,19 @@
             <div class="row">
                 <div class="col-lg-8">
                     <h2 class="mb-4">Produktbeschreibung</h2>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <p class="lead mb-4">Stylische Mode für jeden Anlass. Entdecken Sie zeitlose Eleganz und modernen Komfort in einem.</p>
                     
                     <h3>Hauptmerkmale</h3>
                     <ul class="list-unstyled">
-                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Robuste Konstruktion</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Einfache Bedienung</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Platzsparend</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Wartungsarm</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>3 Jahre Garantie</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Premium Qualität</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Bequemer Sitz</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Stylisch</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Langlebig</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Pflegeleicht</li>
                     </ul>
 
                     <h3 class="mt-4">Technische Spezifikationen</h3>
                     <div class="row">
                         <div class="col-md-6">
-                            <p><strong>Kategorie:</strong> Haushalt</p>
-                            <p><strong>Artikelnummer:</strong> 012</p>
-                            <p><strong>Preis:</strong> €44.00</p>
+                            <p><strong>Kategorie:</strong> Mode</p>
+                            <p><strong>Artikelnummer:</strong> 006</p>
+                            <p><strong>Preis:</strong> €24.00</p>
                         </div>
                         <div class="col-md-6">
                             <p><strong>Verfügbarkeit:</strong> Auf Lager</p>
@@ -110,17 +87,17 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€24.00</div>
+                                <div class="total-price">Gesamt: <span id="totalPrice">€24.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -150,23 +127,23 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
-                                    <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <input type="number" class="quantity-input" id="quantity-desktop" value="1" min="1" max="10">
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€<span id="currentPriceDesktop">24.00</span></div>
+                                <div class="total-price">Gesamt: €<span id="totalPriceDesktop">24.00</span></div>
                             </div>
                             
                             <div class="action-buttons">
                                 <button class="buy-now-btn" id="buyNowBtn">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
-                                <button class="wishlist-btn" onclick="toggleWishlist(product)">
-                                    <i class="bi bi-heart"></i> Zur Wunschliste hinzufügen
+                                <button class="wishlist-btn" id="cardWishlistBtn">
+                                    <i class="bi bi-heart"></i> Zur Wunschliste
                                 </button>
                             </div>
                             
@@ -195,13 +172,13 @@
                 </div>
                 <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3 g-md-4">
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-10.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-4.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 1">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Mode Produkt 1">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Haushalt Produkt 1</h5>
-                            <div class="price-container"><span class="current-price">€15.00</span></div>
+                            <h5 class="product-title">Mode Produkt 1</h5>
+                            <div class="price-container"><span class="current-price">€20.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -210,13 +187,13 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-11.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-5.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Haushalt Produkt 2">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Mode Produkt 2">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Haushalt Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€18.00</span></div>
+                            <h5 class="product-title">Mode Produkt 2</h5>
+                            <div class="price-container"><span class="current-price">€22.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -225,13 +202,13 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-1.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-7.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 1">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 1">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 1</h5>
-                            <div class="price-container"><span class="current-price">€10.00</span></div>
+                            <h5 class="product-title">Fitness Produkt 1</h5>
+                            <div class="price-container"><span class="current-price">€30.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -240,13 +217,13 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-2.html'">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-8.html'">
                         <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 2">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 2">
                         </div>
                         <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€12.00</span></div>
+                            <h5 class="product-title">Fitness Produkt 2</h5>
+                            <div class="price-container"><span class="current-price">€35.00</span></div>
                             <div class="view-product-btn">
                                 <span>Jetzt ansehen</span>
                                 <i class="bi bi-arrow-right"></i>
@@ -269,11 +246,11 @@
     <script>
   // Produktdaten für diese Seite
   const product = {
-    id: 12,
-    name: "Haushalt Produkt 3",
-    price: 44.00,
+    id: 6,
+    name: "Mode Produkt 3",
+    price: 24.00,
     image: "produkt bilder/ware.png",
-    description: "Praktisch und zuverlässig für Ihr Zuhause."
+    description: "Modisch und hochwertig für jeden Anlass. Dieses hochwertige Produkt bietet die perfekte Balance zwischen Funktionalität und Design."
   };
 
   // Bundles dynamisch laden
@@ -289,178 +266,8 @@
       }
     });
 
-  function getWishlist() {
-    return JSON.parse(localStorage.getItem('wishlist')) || [];
-  }
-  function setWishlist(wishlist) {
-    localStorage.setItem('wishlist', JSON.stringify(wishlist));
-  }
-  function isInWishlist(id) {
-    return getWishlist().some(item => Number(item.id) === Number(id));
-  }
-  function toggleWishlist(product) {
-    let wishlist = getWishlist();
-    if (isInWishlist(product.id)) {
-      wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
-      if (typeof showAlert === 'function') {
-        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
-      } else {
-        showNotification('Von der Wunschliste entfernt', 'info');
-      }
-    } else {
-      wishlist.push({
-        id: product.id,
-        name: product.name,
-        price: product.price,
-        image: product.image,
-        description: product.description
-      });
-      if (typeof showAlert === 'function') {
-        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
-      } else {
-        showNotification('Zur Wunschliste hinzugefügt');
-      }
-    }
-    setWishlist(wishlist);
-    updateWishlistButton();
-  }
-  function updateWishlistButton() {
-    const btn = document.getElementById('wishlistBtn');
-    if (!btn) return;
-    if (isInWishlist(product.id)) {
-      btn.classList.add('active');
-      btn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
-    } else {
-      btn.classList.remove('active');
-      btn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste';
-    }
-  }
-  function getCart() {
-    return JSON.parse(localStorage.getItem('cart')) || [];
-            }
-  function setCart(cart) {
-            localStorage.setItem('cart', JSON.stringify(cart));
-  }
-  function addToCart(product) {
-      let cart = getCart();
-      const existing = cart.find(item => Number(item.id) === Number(product.id));
-      if (existing) {
-          existing.quantity += product.quantity || 1;
-      } else {
-          cart.push({ ...product, quantity: product.quantity || 1 });
-      }
-      setCart(cart);
-      // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
-  }
-  
-  // showAlert function for cart popup
-  function showAlert(message, redirectTo = 'cart.html') {
-    const alert = document.createElement('div');
-    alert.className = 'alert alert-success position-fixed end-0 m-4 shadow-lg fade show';
-    alert.style.zIndex = '20000';
-    alert.style.fontSize = '1rem';
-    alert.style.minWidth = '160px';
-    alert.style.maxWidth = '320px';
-    alert.style.padding = '0.75rem 2rem';
-    alert.style.textAlign = 'center';
-    alert.style.borderRadius = '2rem';
-    alert.style.boxShadow = '0 8px 32px rgba(0,0,0,0.18)';
-    alert.style.background = 'linear-gradient(90deg, #4f8cff 0%, #38c6ff 100%)';
-    alert.style.color = '#fff';
-    alert.style.fontWeight = '500';
-    alert.style.letterSpacing = '0.02em';
-    alert.style.pointerEvents = 'auto';
-    alert.style.position = 'fixed';
-    alert.style.right = '2.5rem';
-    alert.style.top = 'calc(56px + 1.2rem)';
-    alert.style.cursor = 'pointer';
-    alert.textContent = message;
-    alert.addEventListener('click', () => {
-      window.location.href = '../' + redirectTo;
-    });
-    document.body.appendChild(alert);
-    setTimeout(() => {
-      if (document.body.contains(alert)) {
-        alert.classList.remove('show');
-        alert.classList.add('fade');
-        setTimeout(() => alert.remove(), 400);
-      }
-    }, 1700);
-  }
-
-  function showNotification(message, type = 'success') {
-    const notification = document.createElement('div');
-    notification.className = `alert alert-${type} position-fixed end-0 m-4 shadow-lg fade show`;
-    notification.style.zIndex = '20000';
-    notification.style.fontSize = '1rem';
-    notification.style.minWidth = '160px';
-    notification.style.maxWidth = '320px';
-    notification.style.padding = '0.75rem 2rem';
-    notification.style.textAlign = 'center';
-    notification.style.borderRadius = '2rem';
-    notification.style.boxShadow = '0 8px 32px rgba(0,0,0,0.18)';
-    notification.style.background = type === 'success' 
-      ? 'linear-gradient(90deg, #4f8cff 0%, #38c6ff 100%)' 
-      : 'linear-gradient(90deg, #ff6b6b 0%, #ee5a24 100%)';
-    notification.style.color = '#fff';
-    notification.style.fontWeight = '500';
-    notification.style.letterSpacing = '0.02em';
-    notification.style.pointerEvents = 'auto';
-    notification.style.position = 'fixed';
-    notification.style.right = '2.5rem';
-    notification.style.top = 'calc(56px + 1.2rem)';
-    notification.style.cursor = 'pointer';
-    notification.textContent = message;
-    
-    // Klick-Event hinzufügen
-    notification.addEventListener('click', function() {
-      notification.classList.remove('show');
-      notification.classList.add('fade');
-      setTimeout(() => notification.remove(), 400);
-      // Zur Wishlist-Seite weiterleiten (aus dem produkte/ Ordner)
-      window.location.href = '../wishlist.html';
-    });
-    
-    document.body.appendChild(notification);
-    
-    setTimeout(() => {
-      if (document.body.contains(notification)) {
-        notification.classList.remove('show');
-        notification.classList.add('fade');
-        setTimeout(() => notification.remove(), 400);
-      }
-    }, 2000);
-  }
-
-  function addBundleToCart(bundle) {
-    let cart = getCart();
-    const bundleId = bundle.bundleId;
-    const existing = cart.find(item => item.bundleId === bundleId);
-    if (existing) {
-        existing.quantity = 1;
-    } else {
-        cart.push({
-            id: product.id,
-            name: bundle.name,
-            price: bundle.price,
-            image: product.image,
-            description: bundle.description,
-            bundleId: bundleId,
-            bundleItems: [], // Keine Items für die neue Staffel
-            quantity: 1
-        });
-    }
-    setCart(cart);
-    // Popup anzeigen statt direkter Weiterleitung
-    if (typeof showAlert === 'function') {
-      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
-    } else {
-      showNotification('Bundle zum Warenkorb hinzugefügt');
-    }
-}
-
   function renderBundles() {
-    const einzelpreis = 44.00;
+    const einzelpreis = 24.00;
     const staffel = [
       {qty:1, price:einzelpreis, original:einzelpreis},
       {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
@@ -478,6 +285,8 @@
               <div class="bundle-info">
                 <div class="bundle-title">
                   ${s.qty} Set${s.qty>1?'s':''} kaufen
+                </div>
+                <div class="bundle-badges">
                   ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
                   ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
                   ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
@@ -487,7 +296,7 @@
                   <span class="old">€${s.original.toFixed(2)}</span>
                   <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
                 </div>
-                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
+                ${s.qty>1?`<div style='margin-top:.7em;font-size:.97rem;'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
               </div>
             </div>
           `).join('')}
@@ -532,121 +341,265 @@
       addBundleToCart({
         id: product.id,
         name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
-        price: s.price * s.qty,
+        price: s.price * s.qty, // Gesamtpreis für das Bundle
         image: product.image,
         description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
         bundleId: `${product.id}-qty${s.qty}`,
-        quantity: s.qty
+        quantity: 1
       });
     });
   }
 
-  renderBundles();
-
-  // Funktionen für die neue Schnellbestellung
-  function increaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue < 10) {
-        input.value = currentValue + 1;
-        updateTotalPrice();
-      }
+  function addBundleToCart(bundle) {
+    let cart = getCart();
+    // Bundle als eigenes Cart-Item mit bundleId
+    const bundleId = bundle.bundleId;
+    const existing = cart.find(item => item.bundleId === bundleId);
+    if (existing) {
+      // Bei Bundles immer nur 1 erlauben
+      existing.quantity = 1;
+    } else {
+      cart.push({
+        id: product.id,
+        name: bundle.name,
+        price: bundle.price,
+        image: product.image,
+        description: bundle.description,
+        bundleId: bundleId,
+        bundleItems: [], // Keine Items für die neue Staffel
+        quantity: 1
+      });
+    }
+    setCart(cart);
+    // Popup anzeigen statt direkter Weiterleitung
+    if (typeof showAlert === 'function') {
+      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
+    } else {
+      showNotification('Bundle zum Warenkorb hinzugefügt');
     }
   }
 
-  function decreaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
+  function getWishlist() {
+    return JSON.parse(localStorage.getItem('wishlist')) || [];
+  }
+  function setWishlist(wishlist) {
+    localStorage.setItem('wishlist', JSON.stringify(wishlist));
+  }
+  function isInWishlist(id) {
+    return getWishlist().some(item => Number(item.id) === Number(id));
+  }
+  function toggleWishlist(product) {
+    let wishlist = getWishlist();
+    if (isInWishlist(product.id)) {
+      wishlist = wishlist.filter(item => Number(item.id) !== Number(product.id));
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt von der Wunschliste entfernt', 'wishlist.html');
+      } else {
+        showNotification('Von der Wunschliste entfernt', 'info');
+      }
+    } else {
+      wishlist.push({
+        id: product.id,
+        name: product.name,
+        price: product.price,
+        image: product.image,
+        description: product.description
+      });
+      if (typeof showAlert === 'function') {
+        showAlert('Produkt zur Wunschliste hinzugefügt', 'wishlist.html');
+      } else {
+        showNotification('Zur Wunschliste hinzugefügt');
+      }
+    }
+    setWishlist(wishlist);
+    updateWishlistButton();
+  }
+  function updateWishlistButton() {
+    const heroBtn = document.getElementById('wishlistBtn');
+    const cardBtn = document.getElementById('cardWishlistBtn');
     
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue > 1) {
-        input.value = currentValue - 1;
-        updateTotalPrice();
+    if (isInWishlist(product.id)) {
+      if (heroBtn) {
+        heroBtn.classList.add('active');
+        heroBtn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
+      }
+      if (cardBtn) {
+        cardBtn.classList.add('active');
+        cardBtn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
+      }
+    } else {
+      if (heroBtn) {
+        heroBtn.classList.remove('active');
+        heroBtn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste';
+      }
+      if (cardBtn) {
+        cardBtn.classList.remove('active');
+        cardBtn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste hinzufügen';
       }
     }
   }
-
-  function updateTotalPrice() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
-    const total = (product.price * quantity).toFixed(2);
-    document.getElementById('totalPrice').textContent = `€${total}`;
+  function getCart() {
+    return JSON.parse(localStorage.getItem('cart')) || [];
+            }
+  function setCart(cart) {
+            localStorage.setItem('cart', JSON.stringify(cart));
+  }
+  function addToCart(product) {
+    let cart = getCart();
+    const existing = cart.find(item => Number(item.id) === Number(product.id));
+    if (existing) {
+      existing.quantity += product.quantity || 1;
+    } else {
+      cart.push({ ...product, quantity: product.quantity || 1 });
+    }
+    setCart(cart);
+    // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
+  }
+  
+  // showAlert function for cart popup
+  function showAlert(message, redirectTo = 'cart.html') {
+    const alert = document.createElement('div');
+    alert.className = 'alert alert-success position-fixed end-0 m-4 shadow-lg fade show';
+    alert.style.zIndex = '20000';
+    alert.style.fontSize = '1rem';
+    alert.style.minWidth = '160px';
+    alert.style.maxWidth = '320px';
+    alert.style.padding = '0.75rem 2rem';
+    alert.style.textAlign = 'center';
+    alert.style.borderRadius = '2rem';
+    alert.style.boxShadow = '0 8px 32px rgba(0,0,0,0.18)';
+    alert.style.background = 'linear-gradient(90deg, #4f8cff 0%, #38c6ff 100%)';
+    alert.style.color = '#fff';
+    alert.style.fontWeight = '500';
+    alert.style.letterSpacing = '0.02em';
+    alert.style.pointerEvents = 'auto';
+    alert.style.position = 'fixed';
+    alert.style.right = '2.5rem';
+    alert.style.top = 'calc(56px + 1.2rem)';
+    alert.style.cursor = 'pointer';
+    alert.textContent = message;
+    alert.addEventListener('click', () => {
+      window.location.href = '../' + redirectTo;
+    });
+    document.body.appendChild(alert);
+    setTimeout(() => {
+      if (document.body.contains(alert)) {
+        alert.classList.remove('show');
+        alert.classList.add('fade');
+        setTimeout(() => alert.remove(), 400);
+      }
+    }, 1700);
+  }
+  
+  function showNotification(message, type = 'success') {
+    const notification = document.createElement('div');
+    notification.className = `alert alert-${type} position-fixed end-0 m-4 shadow-lg fade show`;
+    notification.style.zIndex = '20000';
+    notification.style.fontSize = '1rem';
+    notification.style.minWidth = '160px';
+    notification.style.maxWidth = '320px';
+    notification.style.padding = '0.75rem 2rem';
+    notification.style.textAlign = 'center';
+    notification.style.borderRadius = '2rem';
+    notification.style.boxShadow = '0 8px 32px rgba(0,0,0,0.18)';
+    notification.style.background = type === 'success' 
+      ? 'linear-gradient(90deg, #4f8cff 0%, #38c6ff 100%)' 
+      : 'linear-gradient(90deg, #ff6b6b 0%, #ee5a24 100%)';
+    notification.style.color = '#fff';
+    notification.style.fontWeight = '500';
+    notification.style.letterSpacing = '0.02em';
+    notification.style.pointerEvents = 'auto';
+    notification.style.position = 'fixed';
+    notification.style.right = '2.5rem';
+    notification.style.top = 'calc(56px + 1.2rem)';
+    notification.style.cursor = 'pointer';
+    notification.textContent = message;
+    
+    // Klick-Event hinzufügen
+    notification.addEventListener('click', function() {
+      notification.classList.remove('show');
+      notification.classList.add('fade');
+      setTimeout(() => notification.remove(), 400);
+      // Zur Wishlist-Seite weiterleiten (aus dem produkte/ Ordner)
+      window.location.href = '../wishlist.html';
+    });
+    
+    document.body.appendChild(notification);
+    
+    setTimeout(() => {
+      if (document.body.contains(notification)) {
+        notification.classList.remove('show');
+        notification.classList.add('fade');
+        setTimeout(() => notification.remove(), 400);
+      }
+    }, 2000);
   }
 
 
 
   document.addEventListener('DOMContentLoaded', function() {
-    // Event-Listener für Hero-Buttons
-    const cartBtn = document.getElementById('cartBtn');
-    const wishlistBtn = document.getElementById('wishlistBtn');
-    
-    if (cartBtn) {
-      cartBtn.addEventListener('click', function(e) {
-        e.preventDefault();
-        addToCart({
-            id: product.id,
-            name: product.name,
-            price: product.price,
-            image: product.image,
-            description: product.description,
-            quantity: 1
-        });
-        // Popup anzeigen statt direkter Weiterleitung
-        if (typeof showAlert === 'function') {
-          showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
-        } else {
-          showNotification('Zum Warenkorb hinzugefügt');
-        }
-    });
-    }
-    
-    if (wishlistBtn) {
-      wishlistBtn.addEventListener('click', function(e) {
+    // Hero Wishlist-Button
+    let heroWishlistBtn = document.getElementById('wishlistBtn');
+    if (heroWishlistBtn) {
+      heroWishlistBtn.addEventListener('click', function(e) {
         e.preventDefault();
         toggleWishlist(product);
       });
-      updateWishlistButton();
-    }
-
-    // Event-Listener für Quantity-Input
-    const quantityInput = document.getElementById('quantity');
-    const buyNowBtn = document.getElementById('buyNowBtn');
-    
-    if (quantityInput) {
-      quantityInput.addEventListener('input', updateTotalPrice);
-      quantityInput.addEventListener('change', updateTotalPrice);
-      updateTotalPrice(); // Initialisiere den Preis
     }
     
-    if (buyNowBtn) {
-      buyNowBtn.addEventListener('click', function(e) {
+    // Hero Cart-Button
+    let heroCartBtn = document.getElementById('heroCartBtn');
+    if (heroCartBtn) {
+      heroCartBtn.addEventListener('click', function(e) {
         e.preventDefault();
-        const quantity = parseInt(quantityInput.value, 10) || 1;
+        const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
         const productToCart = {
           ...product,
           quantity: quantity
         };
         addToCart(productToCart);
-        // Popup anzeigen statt direkter Weiterleitung
-        if (typeof showAlert === 'function') {
-          showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
-        } else {
-          showNotification('Zum Warenkorb hinzugefügt');
-        }
       });
     }
-  });
+    
+    // Card Wishlist-Button
+    let cardWishlistBtn = document.getElementById('cardWishlistBtn');
+    if (cardWishlistBtn) {
+      cardWishlistBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        toggleWishlist(product);
+      });
+    }
+    
+    // Update both wishlist buttons on page load
+    updateWishlistButton();
+    
+    // Buy Now Button
+    const quantityInput = document.getElementById('quantity');
+    const buyNowBtn = document.getElementById('buyNowBtn');
+    
+    function updatePrices() {
+      const qty = parseInt(quantityInput.value, 10) || 1;
+      const total = (product.price * qty).toFixed(2);
+      document.getElementById('currentPrice').textContent = product.price.toFixed(2);
+      document.getElementById('totalPrice').textContent = total;
+    }
+    
+    if (quantityInput && buyNowBtn) {
+      quantityInput.addEventListener('input', updatePrices);
+      quantityInput.addEventListener('change', updatePrices);
+      updatePrices();
+      
+      buyNowBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        const qty = parseInt(quantityInput.value, 10) || 1;
+        const productToCart = {
+          ...product,
+          quantity: qty
+        };
+        addToCart(productToCart);
+      });
+    }
+      });
     </script>
 </body>
 </html>

--- a/produkte/produkt-7.html
+++ b/produkte/produkt-7.html
@@ -110,9 +110,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
@@ -120,7 +120,7 @@
                                 <div class="total-price">Gesamt: <span id="totalPrice">€30.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -150,9 +150,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             

--- a/produkte/produkt-7.html.backup
+++ b/produkte/produkt-7.html.backup
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Haushalt Produkt 3 - Marktplatz</title>
+    <title>Fitness Produkt 1 - Marktplatz</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <link href="haushalt.css" rel="stylesheet">
+    <link href="fitness.css" rel="stylesheet">
     <style>
         .product-hero {
-            background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+            background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
             color: white;
             padding: 4rem 0;
         }
@@ -54,21 +54,21 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-6">
-                    <h1 class="display-4 fw-bold mb-3">Haushalt Produkt 3</h1>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <h1 class="display-4 fw-bold mb-3">Fitness Produkt 1</h1>
+                    <p class="lead mb-4">Beschreibungstext für Fitness Produkt 1</p>
                     <div class="d-flex align-items-center gap-3 mb-4">
-                        <span class="price-tag">€44.00</span>
+                        <span class="price-tag">€30.00</span>
                         <span class="badge bg-success">Kostenloser Versand in Europa</span>
                     </div>
-                    <button class="btn btn-light btn-lg me-3" id="cartBtn">
+                    <button class="btn btn-light btn-lg me-3" id="heroCartBtn">
                         <i class="bi bi-cart-plus"></i> In den Warenkorb
                     </button>
                     <button class="btn btn-outline-light btn-lg" id="wishlistBtn">
-                        <i class="bi bi-heart"></i> Merken
+                        <i class="bi bi-heart"></i> Zur Wunschliste
                     </button>
                 </div>
                 <div class="col-lg-6 text-center">
-                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
+                    <img src="../produkt bilder/ware.png" alt="Fitness Produkt 1" class="img-fluid product-image" style="max-height: 400px;">
                 </div>
             </div>
         </div>
@@ -80,19 +80,19 @@
             <div class="row">
                 <div class="col-lg-8">
                     <h2 class="mb-4">Produktbeschreibung</h2>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <p class="lead mb-4">Optimieren Sie Ihr Training mit professioneller Ausrüstung. Für maximale Leistung und dauerhaften Erfolg.</p>
                     
                     <h3>Hauptmerkmale</h3>
                     <ul class="list-unstyled">
-                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Robuste Konstruktion</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Einfache Bedienung</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Platzsparend</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Wartungsarm</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>3 Jahre Garantie</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Professionelle Qualität</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Verstellbar</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Rutschfest</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Langlebig</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>5 Jahre Garantie</li>
                     </ul>
 
                     <h3 class="mt-4">Technische Spezifikationen</h3>
                     <div class="row">
                         <div class="col-md-6">
-                            <p><strong>Kategorie:</strong> Haushalt</p>
-                            <p><strong>Artikelnummer:</strong> 012</p>
-                            <p><strong>Preis:</strong> €44.00</p>
+                            <p><strong>Kategorie:</strong> Fitness</p>
+                            <p><strong>Artikelnummer:</strong> 007</p>
+                            <p><strong>Preis:</strong> €30.00</p>
                         </div>
                         <div class="col-md-6">
                             <p><strong>Verfügbarkeit:</strong> Auf Lager</p>
@@ -110,17 +110,17 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€30.00</div>
+                                <div class="total-price">Gesamt: <span id="totalPrice">€30.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -150,23 +150,23 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€<span id="currentPrice">30.00</span></div>
+                                <div class="total-price">Gesamt: €<span id="totalPrice">30.00</span></div>
                             </div>
                             
                             <div class="action-buttons">
                                 <button class="buy-now-btn" id="buyNowBtn">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
-                                <button class="wishlist-btn" onclick="toggleWishlist(product)">
-                                    <i class="bi bi-heart"></i> Zur Wunschliste hinzufügen
+                                <button class="wishlist-btn" id="cardWishlistBtn">
+                                    <i class="bi bi-heart"></i> Zur Wunschliste
                                 </button>
                             </div>
                             
@@ -194,6 +194,36 @@
                     <p class="section-subtitle">Entdecken Sie weitere Produkte, die Ihnen gefallen könnten</p>
                 </div>
                 <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3 g-md-4">
+                <div class="col">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-8.html'">
+                        <div class="product-image-wrapper">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 2">
+                        </div>
+                        <div class="product-info">
+                            <h5 class="product-title">Fitness Produkt 2</h5>
+                            <div class="price-container"><span class="current-price">€35.00</span></div>
+                            <div class="view-product-btn">
+                                <span>Jetzt ansehen</span>
+                                <i class="bi bi-arrow-right"></i>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-9.html'">
+                        <div class="product-image-wrapper">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 3">
+                        </div>
+                        <div class="product-info">
+                            <h5 class="product-title">Fitness Produkt 3</h5>
+                            <div class="price-container"><span class="current-price">€40.00</span></div>
+                            <div class="view-product-btn">
+                                <span>Jetzt ansehen</span>
+                                <i class="bi bi-arrow-right"></i>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <div class="col">
                     <div class="similar-product-card" onclick="window.location.href='produkt-10.html'">
                         <div class="product-image-wrapper">
@@ -224,36 +254,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-1.html'">
-                        <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 1">
-                        </div>
-                        <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 1</h5>
-                            <div class="price-container"><span class="current-price">€10.00</span></div>
-                            <div class="view-product-btn">
-                                <span>Jetzt ansehen</span>
-                                <i class="bi bi-arrow-right"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-2.html'">
-                        <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 2">
-                        </div>
-                        <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€12.00</span></div>
-                            <div class="view-product-btn">
-                                <span>Jetzt ansehen</span>
-                                <i class="bi bi-arrow-right"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
                 </div>
             </div>
         </section>
@@ -269,11 +269,11 @@
     <script>
   // Produktdaten für diese Seite
   const product = {
-    id: 12,
-    name: "Haushalt Produkt 3",
-    price: 44.00,
+    id: 7,
+    name: "Fitness Produkt 1",
+    price: 30.00,
     image: "produkt bilder/ware.png",
-    description: "Praktisch und zuverlässig für Ihr Zuhause."
+    description: "Für ein aktives und gesundes Leben. Dieses hochwertige Produkt bietet die perfekte Balance zwischen Funktionalität und Design."
   };
 
   // Bundles dynamisch laden
@@ -288,6 +288,117 @@
         renderBundles();
       }
     });
+
+  function renderBundles() {
+    const einzelpreis = 30.00;
+    const staffel = [
+      {qty:1, price:einzelpreis, original:einzelpreis},
+      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
+      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
+    ];
+    const section = document.getElementById('bundle-section');
+    let selected = 1;
+    section.innerHTML = `
+      <div class="bundle-box">
+        <div class="bundle-header">BUNDLE & SPARE</div>
+        <form id="bundleForm">
+          ${staffel.map((s, i) => `
+            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
+              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
+              <div class="bundle-info">
+                <div class="bundle-title">
+                  ${s.qty} Set${s.qty>1?'s':''} kaufen
+                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
+                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
+                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
+                </div>
+                <div class="bundle-prices">
+                  €${s.price.toFixed(2)} pro Set
+                  <span class="old">€${s.original.toFixed(2)}</span>
+                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
+                </div>
+                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
+              </div>
+            </div>
+          `).join('')}
+          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
+        </form>
+      </div>
+    `;
+    // Interaktive Auswahl
+    const cards = section.querySelectorAll('.bundle-card');
+    const radios = section.querySelectorAll('.bundle-radio');
+    
+    // Event-Listener für Radio-Buttons
+    radios.forEach((radio, i) => {
+      radio.addEventListener('change', () => {
+        cards.forEach(c => c.classList.remove('selected'));
+        cards[i].classList.add('selected');
+      });
+    });
+
+    // Event-Listener für Bundle-Cards
+    cards.forEach((card, i) => {
+      card.addEventListener('click', (e) => {
+        // Verhindere Bubbling wenn auf Radio geklickt wurde
+        if (e.target === radios[i]) return;
+        
+        // Wähle Radio-Button aus
+        radios[i].checked = true;
+        
+        // Aktualisiere Selected-Status
+        cards.forEach(c => c.classList.remove('selected'));
+        card.classList.add('selected');
+        
+        // Trigger change Event auf Radio
+        radios[i].dispatchEvent(new Event('change'));
+      });
+    });
+
+    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      const idx = Array.from(radios).findIndex(r => r.checked);
+      const s = staffel[idx];
+      addBundleToCart({
+        id: product.id,
+        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
+        price: s.price * s.qty, // Gesamtpreis für das Bundle
+        image: product.image,
+        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
+        bundleId: `${product.id}-qty${s.qty}`,
+        quantity: 1
+      });
+    });
+  }
+
+  function addBundleToCart(bundle) {
+    let cart = getCart();
+    // Bundle als eigenes Cart-Item mit bundleId
+    const bundleId = `${product.id}-${bundle.id}`;
+    const existing = cart.find(item => item.bundleId === bundleId);
+    if (existing) {
+      // Bei Bundles immer nur 1 erlauben
+      existing.quantity = 1;
+    } else {
+      cart.push({
+        id: product.id,
+        name: product.name + ' - ' + bundle.name,
+        price: bundle.price,
+        image: product.image,
+        description: product.description + ' (Bundle: ' + bundle.name + ')',
+        bundleId: bundleId,
+        bundleItems: bundle.items,
+        quantity: 1
+      });
+    }
+    setCart(cart);
+    // Popup anzeigen statt direkter Weiterleitung
+    if (typeof showAlert === 'function') {
+      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
+    } else {
+      showNotification('Bundle zum Warenkorb hinzugefügt');
+    }
+  }
 
   function getWishlist() {
     return JSON.parse(localStorage.getItem('wishlist')) || [];
@@ -325,14 +436,27 @@
     updateWishlistButton();
   }
   function updateWishlistButton() {
-    const btn = document.getElementById('wishlistBtn');
-    if (!btn) return;
+    const heroBtn = document.getElementById('wishlistBtn');
+    const cardBtn = document.getElementById('cardWishlistBtn');
+    
     if (isInWishlist(product.id)) {
-      btn.classList.add('active');
-      btn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
+      if (heroBtn) {
+        heroBtn.classList.add('active');
+        heroBtn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
+      }
+      if (cardBtn) {
+        cardBtn.classList.add('active');
+        cardBtn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
+      }
     } else {
-      btn.classList.remove('active');
-      btn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste';
+      if (heroBtn) {
+        heroBtn.classList.remove('active');
+        heroBtn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste';
+      }
+      if (cardBtn) {
+        cardBtn.classList.remove('active');
+        cardBtn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste hinzufügen';
+      }
     }
   }
   function getCart() {
@@ -342,15 +466,15 @@
             localStorage.setItem('cart', JSON.stringify(cart));
   }
   function addToCart(product) {
-      let cart = getCart();
-      const existing = cart.find(item => Number(item.id) === Number(product.id));
-      if (existing) {
-          existing.quantity += product.quantity || 1;
-      } else {
-          cart.push({ ...product, quantity: product.quantity || 1 });
-      }
-      setCart(cart);
-      // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
+    let cart = getCart();
+    const existing = cart.find(item => Number(item.id) === Number(product.id));
+    if (existing) {
+      existing.quantity += product.quantity || 1;
+    } else {
+      cart.push({ ...product, quantity: product.quantity || 1 });
+    }
+    setCart(cart);
+    // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
   }
   
   // showAlert function for cart popup
@@ -432,207 +556,59 @@
     }, 2000);
   }
 
-  function addBundleToCart(bundle) {
-    let cart = getCart();
-    const bundleId = bundle.bundleId;
-    const existing = cart.find(item => item.bundleId === bundleId);
-    if (existing) {
-        existing.quantity = 1;
-    } else {
-        cart.push({
-            id: product.id,
-            name: bundle.name,
-            price: bundle.price,
-            image: product.image,
-            description: bundle.description,
-            bundleId: bundleId,
-            bundleItems: [], // Keine Items für die neue Staffel
-            quantity: 1
-        });
-    }
-    setCart(cart);
-    // Popup anzeigen statt direkter Weiterleitung
-    if (typeof showAlert === 'function') {
-      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
-    } else {
-      showNotification('Bundle zum Warenkorb hinzugefügt');
-    }
-}
 
-  function renderBundles() {
-    const einzelpreis = 44.00;
-    const staffel = [
-      {qty:1, price:einzelpreis, original:einzelpreis},
-      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
-      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
-    ];
-    const section = document.getElementById('bundle-section');
-    let selected = 1;
-    section.innerHTML = `
-      <div class="bundle-box">
-        <div class="bundle-header">BUNDLE & SPARE</div>
-        <form id="bundleForm">
-          ${staffel.map((s, i) => `
-            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
-              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
-              <div class="bundle-info">
-                <div class="bundle-title">
-                  ${s.qty} Set${s.qty>1?'s':''} kaufen
-                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
-                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
-                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
-                </div>
-                <div class="bundle-prices">
-                  €${s.price.toFixed(2)} pro Set
-                  <span class="old">€${s.original.toFixed(2)}</span>
-                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
-                </div>
-                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
-              </div>
-            </div>
-          `).join('')}
-          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
-        </form>
-      </div>
-    `;
-    // Interaktive Auswahl
-    const cards = section.querySelectorAll('.bundle-card');
-    const radios = section.querySelectorAll('.bundle-radio');
-    
-    // Event-Listener für Radio-Buttons
-    radios.forEach((radio, i) => {
-      radio.addEventListener('change', () => {
-        cards.forEach(c => c.classList.remove('selected'));
-        cards[i].classList.add('selected');
-      });
-    });
 
-    // Event-Listener für Bundle-Cards
-    cards.forEach((card, i) => {
-      card.addEventListener('click', (e) => {
-        // Verhindere Bubbling wenn auf Radio geklickt wurde
-        if (e.target === radios[i]) return;
-        
-        // Wähle Radio-Button aus
-        radios[i].checked = true;
-        
-        // Aktualisiere Selected-Status
-        cards.forEach(c => c.classList.remove('selected'));
-        card.classList.add('selected');
-        
-        // Trigger change Event auf Radio
-        radios[i].dispatchEvent(new Event('change'));
-      });
-    });
-
-    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
-      e.preventDefault();
-      const idx = Array.from(radios).findIndex(r => r.checked);
-      const s = staffel[idx];
-      addBundleToCart({
-        id: product.id,
-        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
-        price: s.price * s.qty,
-        image: product.image,
-        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
-        bundleId: `${product.id}-qty${s.qty}`,
-        quantity: s.qty
-      });
-    });
-  }
-
-  renderBundles();
-
-  // Funktionen für die neue Schnellbestellung
-  function increaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue < 10) {
-        input.value = currentValue + 1;
-        updateTotalPrice();
-      }
+  // Mengenfunktionen für Schnellbestellung
+  function decreaseQuantity() {
+    const quantityInput = document.getElementById('quantity');
+    const currentValue = parseInt(quantityInput.value, 10) || 1;
+    if (currentValue > 1) {
+      quantityInput.value = currentValue - 1;
+      updatePrices();
     }
   }
 
-  function decreaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue > 1) {
-        input.value = currentValue - 1;
-        updateTotalPrice();
-      }
+  function increaseQuantity() {
+    const quantityInput = document.getElementById('quantity');
+    const currentValue = parseInt(quantityInput.value, 10) || 1;
+    if (currentValue < 10) {
+      quantityInput.value = currentValue + 1;
+      updatePrices();
     }
   }
 
-  function updateTotalPrice() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
-    const total = (product.price * quantity).toFixed(2);
-    document.getElementById('totalPrice').textContent = `€${total}`;
+  function updatePrices() {
+    const quantityInput = document.getElementById('quantity');
+    const currentPriceSpan = document.getElementById('currentPrice');
+    const totalPriceSpan = document.getElementById('totalPrice');
+    const buyBtn = document.querySelector('.buy-now-btn');
+    
+    const qty = parseInt(quantityInput.value, 10) || 1;
+    const total = (product.price * qty).toFixed(2);
+    
+    if (currentPriceSpan) currentPriceSpan.textContent = product.price.toFixed(2);
+    if (totalPriceSpan) totalPriceSpan.textContent = total;
+    if (buyBtn) {
+      buyBtn.innerHTML = `<i class="bi bi-cart-plus"></i> Jetzt kaufen - €${total}`;
+    }
   }
-
-
 
   document.addEventListener('DOMContentLoaded', function() {
-    // Event-Listener für Hero-Buttons
-    const cartBtn = document.getElementById('cartBtn');
-    const wishlistBtn = document.getElementById('wishlistBtn');
-    
-    if (cartBtn) {
-      cartBtn.addEventListener('click', function(e) {
-        e.preventDefault();
-        addToCart({
-            id: product.id,
-            name: product.name,
-            price: product.price,
-            image: product.image,
-            description: product.description,
-            quantity: 1
-        });
-        // Popup anzeigen statt direkter Weiterleitung
-        if (typeof showAlert === 'function') {
-          showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
-        } else {
-          showNotification('Zum Warenkorb hinzugefügt');
-        }
-    });
-    }
-    
-    if (wishlistBtn) {
-      wishlistBtn.addEventListener('click', function(e) {
+    // Hero Wishlist-Button
+    let heroWishlistBtn = document.getElementById('wishlistBtn');
+    if (heroWishlistBtn) {
+      heroWishlistBtn.addEventListener('click', function(e) {
         e.preventDefault();
         toggleWishlist(product);
       });
-      updateWishlistButton();
-    }
-
-    // Event-Listener für Quantity-Input
-    const quantityInput = document.getElementById('quantity');
-    const buyNowBtn = document.getElementById('buyNowBtn');
-    
-    if (quantityInput) {
-      quantityInput.addEventListener('input', updateTotalPrice);
-      quantityInput.addEventListener('change', updateTotalPrice);
-      updateTotalPrice(); // Initialisiere den Preis
     }
     
-    if (buyNowBtn) {
-      buyNowBtn.addEventListener('click', function(e) {
+    // Hero Cart-Button
+    let heroCartBtn = document.getElementById('heroCartBtn');
+    if (heroCartBtn) {
+      heroCartBtn.addEventListener('click', function(e) {
         e.preventDefault();
-        const quantity = parseInt(quantityInput.value, 10) || 1;
+        const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
         const productToCart = {
           ...product,
           quantity: quantity
@@ -646,7 +622,45 @@
         }
       });
     }
-  });
+    
+    // Card Wishlist-Button
+    let cardWishlistBtn = document.getElementById('cardWishlistBtn');
+    if (cardWishlistBtn) {
+      cardWishlistBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        toggleWishlist(product);
+      });
+    }
+    
+    // Update both wishlist buttons on page load
+    updateWishlistButton();
+    
+    // Buy Now Button
+    const quantityInput = document.getElementById('quantity');
+    const buyNowBtn = document.getElementById('buyNowBtn');
+    
+    if (quantityInput && buyNowBtn) {
+      quantityInput.addEventListener('input', updatePrices);
+      quantityInput.addEventListener('change', updatePrices);
+      updatePrices();
+      
+      buyNowBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        const qty = parseInt(quantityInput.value, 10) || 1;
+        const productToCart = {
+          ...product,
+          quantity: qty
+        };
+        addToCart(productToCart);
+        // Popup anzeigen statt direkter Weiterleitung
+        if (typeof showAlert === 'function') {
+          showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
+        } else {
+          showNotification('Zum Warenkorb hinzugefügt');
+        }
+      });
+    }
+      });
     </script>
 </body>
 </html>

--- a/produkte/produkt-8.html
+++ b/produkte/produkt-8.html
@@ -114,9 +114,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
@@ -124,7 +124,7 @@
                                 <div class="total-price">Gesamt: <span id="totalPrice">€42.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -154,9 +154,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             

--- a/produkte/produkt-8.html.backup
+++ b/produkte/produkt-8.html.backup
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Haushalt Produkt 3 - Marktplatz</title>
+    <title>Fitness Produkt 2 - Marktplatz</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <link href="haushalt.css" rel="stylesheet">
+    <link href="fitness.css" rel="stylesheet">
     <style>
         .product-hero {
-            background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+            background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
             color: white;
             padding: 4rem 0;
         }
@@ -54,21 +54,21 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-6">
-                    <h1 class="display-4 fw-bold mb-3">Haushalt Produkt 3</h1>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <h1 class="display-4 fw-bold mb-3">Fitness Produkt 2</h1>
+                    <p class="lead mb-4">Für ein aktives und gesundes Leben. Optimieren Sie Ihr Training mit professioneller Ausstattung.</p>
                     <div class="d-flex align-items-center gap-3 mb-4">
-                        <span class="price-tag">€44.00</span>
+                        <span class="price-tag">€42.00</span>
                         <span class="badge bg-success">Kostenloser Versand in Europa</span>
                     </div>
-                    <button class="btn btn-light btn-lg me-3" id="cartBtn">
+                    <button class="btn btn-light btn-lg me-3" id="heroCartBtn">
                         <i class="bi bi-cart-plus"></i> In den Warenkorb
                     </button>
                     <button class="btn btn-outline-light btn-lg" id="wishlistBtn">
-                        <i class="bi bi-heart"></i> Merken
+                        <i class="bi bi-heart"></i> Zur Wunschliste
                     </button>
                 </div>
                 <div class="col-lg-6 text-center">
-                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
+                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 2" class="img-fluid product-image" style="max-height: 400px;">
                 </div>
             </div>
         </div>
@@ -80,19 +80,23 @@
             <div class="row">
                 <div class="col-lg-8">
                     <h2 class="mb-4">Produktbeschreibung</h2>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <p class="lead mb-4">Für ein aktives und gesundes Leben. Optimieren Sie Ihr Training mit professioneller Ausstattung.</p>
                     
                     <h3>Hauptmerkmale</h3>
                     <ul class="list-unstyled">
-                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Robuste Konstruktion</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Einfache Bedienung</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Platzsparend</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Wartungsarm</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>3 Jahre Garantie</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Praktische Anwendung</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Zuverlässige Qualität</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Einfache Bedienung</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Langlebig</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>5 Jahre Garantie</li>
                     </ul>
 
                     <h3 class="mt-4">Technische Spezifikationen</h3>
                     <div class="row">
                         <div class="col-md-6">
-                            <p><strong>Kategorie:</strong> Haushalt</p>
-                            <p><strong>Artikelnummer:</strong> 012</p>
-                            <p><strong>Preis:</strong> €44.00</p>
+                            <p><strong>Kategorie:</strong> Fitness</p>
+                            <p><strong>Artikelnummer:</strong> 008</p>
+                            <p><strong>Preis:</strong> €42.00</p>
                         </div>
                         <div class="col-md-6">
                             <p><strong>Verfügbarkeit:</strong> Auf Lager</p>
@@ -110,17 +114,17 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€42.00</div>
+                                <div class="total-price">Gesamt: <span id="totalPrice">€42.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -150,23 +154,23 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€<span id="currentPrice">42.00</span></div>
+                                <div class="total-price">Gesamt: €<span id="totalPrice">42.00</span></div>
                             </div>
                             
                             <div class="action-buttons">
                                 <button class="buy-now-btn" id="buyNowBtn">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
-                                <button class="wishlist-btn" onclick="toggleWishlist(product)">
-                                    <i class="bi bi-heart"></i> Zur Wunschliste hinzufügen
+                                <button class="wishlist-btn" id="cardWishlistBtn">
+                                    <i class="bi bi-heart"></i> Zur Wunschliste
                                 </button>
                             </div>
                             
@@ -194,6 +198,36 @@
                     <p class="section-subtitle">Entdecken Sie weitere Produkte, die Ihnen gefallen könnten</p>
                 </div>
                 <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3 g-md-4">
+                <div class="col">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-7.html'">
+                        <div class="product-image-wrapper">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 1">
+                        </div>
+                        <div class="product-info">
+                            <h5 class="product-title">Fitness Produkt 1</h5>
+                            <div class="price-container"><span class="current-price">€30.00</span></div>
+                            <div class="view-product-btn">
+                                <span>Jetzt ansehen</span>
+                                <i class="bi bi-arrow-right"></i>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-9.html'">
+                        <div class="product-image-wrapper">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 3">
+                        </div>
+                        <div class="product-info">
+                            <h5 class="product-title">Fitness Produkt 3</h5>
+                            <div class="price-container"><span class="current-price">€40.00</span></div>
+                            <div class="view-product-btn">
+                                <span>Jetzt ansehen</span>
+                                <i class="bi bi-arrow-right"></i>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <div class="col">
                     <div class="similar-product-card" onclick="window.location.href='produkt-10.html'">
                         <div class="product-image-wrapper">
@@ -224,36 +258,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-1.html'">
-                        <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 1">
-                        </div>
-                        <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 1</h5>
-                            <div class="price-container"><span class="current-price">€10.00</span></div>
-                            <div class="view-product-btn">
-                                <span>Jetzt ansehen</span>
-                                <i class="bi bi-arrow-right"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-2.html'">
-                        <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 2">
-                        </div>
-                        <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€12.00</span></div>
-                            <div class="view-product-btn">
-                                <span>Jetzt ansehen</span>
-                                <i class="bi bi-arrow-right"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
                 </div>
             </div>
         </section>
@@ -269,11 +273,11 @@
     <script>
   // Produktdaten für diese Seite
   const product = {
-    id: 12,
-    name: "Haushalt Produkt 3",
-    price: 44.00,
+    id: 8,
+    name: "Fitness Produkt 2",
+    price: 42.00,
     image: "produkt bilder/ware.png",
-    description: "Praktisch und zuverlässig für Ihr Zuhause."
+    description: "Für ein aktives und gesundes Leben. Optimieren Sie Ihr Training mit professioneller Ausstattung."
   };
 
   // Bundles dynamisch laden
@@ -282,12 +286,123 @@
     .then(products => {
       const prod = products.find(p => p.id === product.id);
       if (prod && prod.bundles && prod.bundles.length > 0) {
-        renderBundles(prod.bundles);
+        renderBundles();
       } else {
         // Fallback: Bundle-Box immer anzeigen
         renderBundles();
       }
     });
+
+  function renderBundles() {
+    const einzelpreis = 42.00;
+    const staffel = [
+      {qty:1, price:einzelpreis, original:einzelpreis},
+      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
+      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
+    ];
+    const section = document.getElementById('bundle-section');
+    let selected = 1;
+    section.innerHTML = `
+      <div class="bundle-box">
+        <div class="bundle-header">BUNDLE & SPARE</div>
+        <form id="bundleForm">
+          ${staffel.map((s, i) => `
+            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
+              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
+              <div class="bundle-info">
+                <div class="bundle-title">
+                  ${s.qty} Set${s.qty>1?'s':''} kaufen
+                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
+                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
+                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
+                </div>
+                <div class="bundle-prices">
+                  €${s.price.toFixed(2)} pro Set
+                  <span class="old">€${s.original.toFixed(2)}</span>
+                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
+                </div>
+                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
+              </div>
+            </div>
+          `).join('')}
+          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
+        </form>
+      </div>
+    `;
+    // Interaktive Auswahl
+    const cards = section.querySelectorAll('.bundle-card');
+    const radios = section.querySelectorAll('.bundle-radio');
+    
+    // Event-Listener für Radio-Buttons
+    radios.forEach((radio, i) => {
+      radio.addEventListener('change', () => {
+        cards.forEach(c => c.classList.remove('selected'));
+        cards[i].classList.add('selected');
+      });
+    });
+
+    // Event-Listener für Bundle-Cards
+    cards.forEach((card, i) => {
+      card.addEventListener('click', (e) => {
+        // Verhindere Bubbling wenn auf Radio geklickt wurde
+        if (e.target === radios[i]) return;
+        
+        // Wähle Radio-Button aus
+        radios[i].checked = true;
+        
+        // Aktualisiere Selected-Status
+        cards.forEach(c => c.classList.remove('selected'));
+        card.classList.add('selected');
+        
+        // Trigger change Event auf Radio
+        radios[i].dispatchEvent(new Event('change'));
+      });
+    });
+
+    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      const idx = Array.from(radios).findIndex(r => r.checked);
+      const s = staffel[idx];
+      addBundleToCart({
+        id: product.id,
+        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
+        price: s.price * s.qty, // Gesamtpreis für das Bundle
+        image: product.image,
+        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
+        bundleId: `${product.id}-qty${s.qty}`,
+        quantity: 1
+      });
+    });
+  }
+
+  function addBundleToCart(bundle) {
+    let cart = getCart();
+    // Bundle als eigenes Cart-Item mit bundleId
+    const bundleId = `${product.id}-${bundle.id}`;
+    const existing = cart.find(item => item.bundleId === bundleId);
+    if (existing) {
+      // Bei Bundles immer nur 1 erlauben
+      existing.quantity = 1;
+    } else {
+      cart.push({
+        id: product.id,
+        name: product.name + ' - ' + bundle.name,
+        price: bundle.price,
+        image: product.image,
+        description: product.description + ' (Bundle: ' + bundle.name + ')',
+        bundleId: bundleId,
+        bundleItems: bundle.items,
+        quantity: 1
+      });
+    }
+    setCart(cart);
+    // Popup anzeigen statt direkter Weiterleitung
+    if (typeof showAlert === 'function') {
+      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
+    } else {
+      showNotification('Bundle zum Warenkorb hinzugefügt');
+    }
+  }
 
   function getWishlist() {
     return JSON.parse(localStorage.getItem('wishlist')) || [];
@@ -325,14 +440,27 @@
     updateWishlistButton();
   }
   function updateWishlistButton() {
-    const btn = document.getElementById('wishlistBtn');
-    if (!btn) return;
+    const heroBtn = document.getElementById('wishlistBtn');
+    const cardBtn = document.getElementById('cardWishlistBtn');
+    
     if (isInWishlist(product.id)) {
-      btn.classList.add('active');
-      btn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
+      if (heroBtn) {
+        heroBtn.classList.add('active');
+        heroBtn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
+      }
+      if (cardBtn) {
+        cardBtn.classList.add('active');
+        cardBtn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
+      }
     } else {
-      btn.classList.remove('active');
-      btn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste';
+      if (heroBtn) {
+        heroBtn.classList.remove('active');
+        heroBtn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste';
+      }
+      if (cardBtn) {
+        cardBtn.classList.remove('active');
+        cardBtn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste hinzufügen';
+      }
     }
   }
   function getCart() {
@@ -342,15 +470,15 @@
             localStorage.setItem('cart', JSON.stringify(cart));
   }
   function addToCart(product) {
-      let cart = getCart();
-      const existing = cart.find(item => Number(item.id) === Number(product.id));
-      if (existing) {
-          existing.quantity += product.quantity || 1;
-      } else {
-          cart.push({ ...product, quantity: product.quantity || 1 });
-      }
-      setCart(cart);
-      // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
+    let cart = getCart();
+    const existing = cart.find(item => Number(item.id) === Number(product.id));
+    if (existing) {
+      existing.quantity += product.quantity || 1;
+    } else {
+      cart.push({ ...product, quantity: product.quantity || 1 });
+    }
+    setCart(cart);
+    // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
   }
   
   // showAlert function for cart popup
@@ -432,207 +560,59 @@
     }, 2000);
   }
 
-  function addBundleToCart(bundle) {
-    let cart = getCart();
-    const bundleId = bundle.bundleId;
-    const existing = cart.find(item => item.bundleId === bundleId);
-    if (existing) {
-        existing.quantity = 1;
-    } else {
-        cart.push({
-            id: product.id,
-            name: bundle.name,
-            price: bundle.price,
-            image: product.image,
-            description: bundle.description,
-            bundleId: bundleId,
-            bundleItems: [], // Keine Items für die neue Staffel
-            quantity: 1
-        });
-    }
-    setCart(cart);
-    // Popup anzeigen statt direkter Weiterleitung
-    if (typeof showAlert === 'function') {
-      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
-    } else {
-      showNotification('Bundle zum Warenkorb hinzugefügt');
-    }
-}
 
-  function renderBundles() {
-    const einzelpreis = 44.00;
-    const staffel = [
-      {qty:1, price:einzelpreis, original:einzelpreis},
-      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
-      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
-    ];
-    const section = document.getElementById('bundle-section');
-    let selected = 1;
-    section.innerHTML = `
-      <div class="bundle-box">
-        <div class="bundle-header">BUNDLE & SPARE</div>
-        <form id="bundleForm">
-          ${staffel.map((s, i) => `
-            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
-              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
-              <div class="bundle-info">
-                <div class="bundle-title">
-                  ${s.qty} Set${s.qty>1?'s':''} kaufen
-                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
-                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
-                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
-                </div>
-                <div class="bundle-prices">
-                  €${s.price.toFixed(2)} pro Set
-                  <span class="old">€${s.original.toFixed(2)}</span>
-                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
-                </div>
-                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
-              </div>
-            </div>
-          `).join('')}
-          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
-        </form>
-      </div>
-    `;
-    // Interaktive Auswahl
-    const cards = section.querySelectorAll('.bundle-card');
-    const radios = section.querySelectorAll('.bundle-radio');
-    
-    // Event-Listener für Radio-Buttons
-    radios.forEach((radio, i) => {
-      radio.addEventListener('change', () => {
-        cards.forEach(c => c.classList.remove('selected'));
-        cards[i].classList.add('selected');
-      });
-    });
 
-    // Event-Listener für Bundle-Cards
-    cards.forEach((card, i) => {
-      card.addEventListener('click', (e) => {
-        // Verhindere Bubbling wenn auf Radio geklickt wurde
-        if (e.target === radios[i]) return;
-        
-        // Wähle Radio-Button aus
-        radios[i].checked = true;
-        
-        // Aktualisiere Selected-Status
-        cards.forEach(c => c.classList.remove('selected'));
-        card.classList.add('selected');
-        
-        // Trigger change Event auf Radio
-        radios[i].dispatchEvent(new Event('change'));
-      });
-    });
-
-    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
-      e.preventDefault();
-      const idx = Array.from(radios).findIndex(r => r.checked);
-      const s = staffel[idx];
-      addBundleToCart({
-        id: product.id,
-        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
-        price: s.price * s.qty,
-        image: product.image,
-        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
-        bundleId: `${product.id}-qty${s.qty}`,
-        quantity: s.qty
-      });
-    });
-  }
-
-  renderBundles();
-
-  // Funktionen für die neue Schnellbestellung
-  function increaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue < 10) {
-        input.value = currentValue + 1;
-        updateTotalPrice();
-      }
+  // Mengenfunktionen für Schnellbestellung
+  function decreaseQuantity() {
+    const quantityInput = document.getElementById('quantity');
+    const currentValue = parseInt(quantityInput.value, 10) || 1;
+    if (currentValue > 1) {
+      quantityInput.value = currentValue - 1;
+      updatePrices();
     }
   }
 
-  function decreaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue > 1) {
-        input.value = currentValue - 1;
-        updateTotalPrice();
-      }
+  function increaseQuantity() {
+    const quantityInput = document.getElementById('quantity');
+    const currentValue = parseInt(quantityInput.value, 10) || 1;
+    if (currentValue < 10) {
+      quantityInput.value = currentValue + 1;
+      updatePrices();
     }
   }
 
-  function updateTotalPrice() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
-    const total = (product.price * quantity).toFixed(2);
-    document.getElementById('totalPrice').textContent = `€${total}`;
+  function updatePrices() {
+    const quantityInput = document.getElementById('quantity');
+    const currentPriceSpan = document.getElementById('currentPrice');
+    const totalPriceSpan = document.getElementById('totalPrice');
+    const buyBtn = document.querySelector('.buy-now-btn');
+    
+    const qty = parseInt(quantityInput.value, 10) || 1;
+    const total = (product.price * qty).toFixed(2);
+    
+    if (currentPriceSpan) currentPriceSpan.textContent = product.price.toFixed(2);
+    if (totalPriceSpan) totalPriceSpan.textContent = total;
+    if (buyBtn) {
+      buyBtn.innerHTML = `<i class="bi bi-cart-plus"></i> Jetzt kaufen - €${total}`;
+    }
   }
-
-
 
   document.addEventListener('DOMContentLoaded', function() {
-    // Event-Listener für Hero-Buttons
-    const cartBtn = document.getElementById('cartBtn');
-    const wishlistBtn = document.getElementById('wishlistBtn');
-    
-    if (cartBtn) {
-      cartBtn.addEventListener('click', function(e) {
-        e.preventDefault();
-        addToCart({
-            id: product.id,
-            name: product.name,
-            price: product.price,
-            image: product.image,
-            description: product.description,
-            quantity: 1
-        });
-        // Popup anzeigen statt direkter Weiterleitung
-        if (typeof showAlert === 'function') {
-          showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
-        } else {
-          showNotification('Zum Warenkorb hinzugefügt');
-        }
-    });
-    }
-    
-    if (wishlistBtn) {
-      wishlistBtn.addEventListener('click', function(e) {
+    // Hero Wishlist-Button
+    let heroWishlistBtn = document.getElementById('wishlistBtn');
+    if (heroWishlistBtn) {
+      heroWishlistBtn.addEventListener('click', function(e) {
         e.preventDefault();
         toggleWishlist(product);
       });
-      updateWishlistButton();
-    }
-
-    // Event-Listener für Quantity-Input
-    const quantityInput = document.getElementById('quantity');
-    const buyNowBtn = document.getElementById('buyNowBtn');
-    
-    if (quantityInput) {
-      quantityInput.addEventListener('input', updateTotalPrice);
-      quantityInput.addEventListener('change', updateTotalPrice);
-      updateTotalPrice(); // Initialisiere den Preis
     }
     
-    if (buyNowBtn) {
-      buyNowBtn.addEventListener('click', function(e) {
+    // Hero Cart-Button
+    let heroCartBtn = document.getElementById('heroCartBtn');
+    if (heroCartBtn) {
+      heroCartBtn.addEventListener('click', function(e) {
         e.preventDefault();
-        const quantity = parseInt(quantityInput.value, 10) || 1;
+        const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
         const productToCart = {
           ...product,
           quantity: quantity
@@ -646,7 +626,45 @@
         }
       });
     }
-  });
+    
+    // Card Wishlist-Button
+    let cardWishlistBtn = document.getElementById('cardWishlistBtn');
+    if (cardWishlistBtn) {
+      cardWishlistBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        toggleWishlist(product);
+      });
+    }
+    
+    // Update both wishlist buttons on page load
+    updateWishlistButton();
+    
+    // Buy Now Button
+    const quantityInput = document.getElementById('quantity');
+    const buyNowBtn = document.getElementById('buyNowBtn');
+    
+    if (quantityInput && buyNowBtn) {
+      quantityInput.addEventListener('input', updatePrices);
+      quantityInput.addEventListener('change', updatePrices);
+      updatePrices();
+      
+      buyNowBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        const qty = parseInt(quantityInput.value, 10) || 1;
+        const productToCart = {
+          ...product,
+          quantity: qty
+        };
+        addToCart(productToCart);
+        // Popup anzeigen statt direkter Weiterleitung
+        if (typeof showAlert === 'function') {
+          showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
+        } else {
+          showNotification('Zum Warenkorb hinzugefügt');
+        }
+      });
+    }
+      });
     </script>
 </body>
 </html>

--- a/produkte/produkt-9.html
+++ b/produkte/produkt-9.html
@@ -110,9 +110,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
@@ -120,7 +120,7 @@
                                 <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -150,9 +150,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
                                 </div>
                             </div>
                             

--- a/produkte/produkt-9.html.backup
+++ b/produkte/produkt-9.html.backup
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Haushalt Produkt 3 - Marktplatz</title>
+    <title>Fitness Produkt 3 - Marktplatz</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <link href="haushalt.css" rel="stylesheet">
+    <link href="fitness.css" rel="stylesheet">
     <style>
         .product-hero {
-            background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+            background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
             color: white;
             padding: 4rem 0;
         }
@@ -54,21 +54,21 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-6">
-                    <h1 class="display-4 fw-bold mb-3">Haushalt Produkt 3</h1>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <h1 class="display-4 fw-bold mb-3">Fitness Produkt 3</h1>
+                    <p class="lead mb-4">Für ein aktives und gesundes Leben. Optimieren Sie Ihr Training mit professioneller Ausrüstung.</p>
                     <div class="d-flex align-items-center gap-3 mb-4">
                         <span class="price-tag">€44.00</span>
                         <span class="badge bg-success">Kostenloser Versand in Europa</span>
                     </div>
-                    <button class="btn btn-light btn-lg me-3" id="cartBtn">
+                    <button class="btn btn-light btn-lg me-3" id="heroCartBtn">
                         <i class="bi bi-cart-plus"></i> In den Warenkorb
                     </button>
                     <button class="btn btn-outline-light btn-lg" id="wishlistBtn">
-                        <i class="bi bi-heart"></i> Merken
+                        <i class="bi bi-heart"></i> Zur Wunschliste
                     </button>
                 </div>
                 <div class="col-lg-6 text-center">
-                    <img src="../produkt bilder/ware.png" alt="Haushalt Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
+                    <img src="../produkt bilder/ware.png" alt="Fitness Produkt 3" class="img-fluid product-image" style="max-height: 400px;">
                 </div>
             </div>
         </div>
@@ -80,18 +80,18 @@
             <div class="row">
                 <div class="col-lg-8">
                     <h2 class="mb-4">Produktbeschreibung</h2>
-                    <p class="lead mb-4">Praktische Lösungen für Ihren Haushalt. Qualität und Funktionalität für ein angenehmes Zuhause.</p>
+                    <p class="lead mb-4">Optimieren Sie Ihr Training mit professioneller Ausrüstung. Für maximale Leistung und dauerhaften Erfolg.</p>
                     
                     <h3>Hauptmerkmale</h3>
                     <ul class="list-unstyled">
-                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Robuste Konstruktion</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Einfache Bedienung</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Platzsparend</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Wartungsarm</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>3 Jahre Garantie</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Professionelle Qualität</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Verstellbar</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Rutschfest</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Langlebig</li><li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>5 Jahre Garantie</li>
                     </ul>
 
                     <h3 class="mt-4">Technische Spezifikationen</h3>
                     <div class="row">
                         <div class="col-md-6">
-                            <p><strong>Kategorie:</strong> Haushalt</p>
-                            <p><strong>Artikelnummer:</strong> 012</p>
+                            <p><strong>Kategorie:</strong> Fitness</p>
+                            <p><strong>Artikelnummer:</strong> 009</p>
                             <p><strong>Preis:</strong> €44.00</p>
                         </div>
                         <div class="col-md-6">
@@ -110,9 +110,9 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             <div class="price-section">
@@ -120,7 +120,7 @@
                                 <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
                             </div>
                             <div class="action-buttons">
-                                <button class="buy-now-btn" onclick="addToCartWithQuantity(event)">
+                                <button class="buy-now-btn" onclick="addToCartWithQuantity()">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
                                 <button class="wishlist-btn" onclick="toggleWishlist(product)">
@@ -150,23 +150,23 @@
                             <div class="quantity-section">
                                 <label class="quantity-label">Menge:</label>
                                 <div class="quantity-input-group">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(event)">-</button>
+                                    <button class="quantity-btn" onclick="decreaseQuantity()">-</button>
                                     <input type="number" class="quantity-input" id="quantity" value="1" min="1" max="10">
-                                    <button class="quantity-btn" onclick="increaseQuantity(event)">+</button>
+                                    <button class="quantity-btn" onclick="increaseQuantity()">+</button>
                                 </div>
                             </div>
                             
                             <div class="price-section">
-                                <div class="current-price">€44.00</div>
-                                <div class="total-price">Gesamt: <span id="totalPrice">€44.00</span></div>
+                                <div class="current-price">€<span id="currentPrice">44.00</span></div>
+                                <div class="total-price">Gesamt: €<span id="totalPrice">44.00</span></div>
                             </div>
                             
                             <div class="action-buttons">
                                 <button class="buy-now-btn" id="buyNowBtn">
                                     <i class="bi bi-cart-plus"></i> Jetzt kaufen
                                 </button>
-                                <button class="wishlist-btn" onclick="toggleWishlist(product)">
-                                    <i class="bi bi-heart"></i> Zur Wunschliste hinzufügen
+                                <button class="wishlist-btn" id="cardWishlistBtn">
+                                    <i class="bi bi-heart"></i> Zur Wunschliste
                                 </button>
                             </div>
                             
@@ -194,6 +194,36 @@
                     <p class="section-subtitle">Entdecken Sie weitere Produkte, die Ihnen gefallen könnten</p>
                 </div>
                 <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3 g-md-4">
+                <div class="col">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-7.html'">
+                        <div class="product-image-wrapper">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 1">
+                        </div>
+                        <div class="product-info">
+                            <h5 class="product-title">Fitness Produkt 1</h5>
+                            <div class="price-container"><span class="current-price">€30.00</span></div>
+                            <div class="view-product-btn">
+                                <span>Jetzt ansehen</span>
+                                <i class="bi bi-arrow-right"></i>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="similar-product-card" onclick="window.location.href='produkt-8.html'">
+                        <div class="product-image-wrapper">
+                            <img src="../produkt bilder/ware.png" class="product-image" alt="Fitness Produkt 2">
+                        </div>
+                        <div class="product-info">
+                            <h5 class="product-title">Fitness Produkt 2</h5>
+                            <div class="price-container"><span class="current-price">€35.00</span></div>
+                            <div class="view-product-btn">
+                                <span>Jetzt ansehen</span>
+                                <i class="bi bi-arrow-right"></i>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <div class="col">
                     <div class="similar-product-card" onclick="window.location.href='produkt-10.html'">
                         <div class="product-image-wrapper">
@@ -224,36 +254,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-1.html'">
-                        <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 1">
-                        </div>
-                        <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 1</h5>
-                            <div class="price-container"><span class="current-price">€10.00</span></div>
-                            <div class="view-product-btn">
-                                <span>Jetzt ansehen</span>
-                                <i class="bi bi-arrow-right"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="similar-product-card" onclick="window.location.href='produkt-2.html'">
-                        <div class="product-image-wrapper">
-                            <img src="../produkt bilder/ware.png" class="product-image" alt="Elektronik Produkt 2">
-                        </div>
-                        <div class="product-info">
-                            <h5 class="product-title">Elektronik Produkt 2</h5>
-                            <div class="price-container"><span class="current-price">€12.00</span></div>
-                            <div class="view-product-btn">
-                                <span>Jetzt ansehen</span>
-                                <i class="bi bi-arrow-right"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
                 </div>
             </div>
         </section>
@@ -269,11 +269,11 @@
     <script>
   // Produktdaten für diese Seite
   const product = {
-    id: 12,
-    name: "Haushalt Produkt 3",
+    id: 9,
+    name: "Fitness Produkt 3",
     price: 44.00,
     image: "produkt bilder/ware.png",
-    description: "Praktisch und zuverlässig für Ihr Zuhause."
+    description: "Für ein aktives und gesundes Leben. Optimieren Sie Ihr Training mit professioneller Ausrüstung."
   };
 
   // Bundles dynamisch laden
@@ -282,12 +282,123 @@
     .then(products => {
       const prod = products.find(p => p.id === product.id);
       if (prod && prod.bundles && prod.bundles.length > 0) {
-        renderBundles(prod.bundles);
+        renderBundles();
       } else {
         // Fallback: Bundle-Box immer anzeigen
         renderBundles();
       }
     });
+
+  function renderBundles() {
+    const einzelpreis = 44.00;
+    const staffel = [
+      {qty:1, price:einzelpreis, original:einzelpreis},
+      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
+      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
+    ];
+    const section = document.getElementById('bundle-section');
+    let selected = 1;
+    section.innerHTML = `
+      <div class="bundle-box">
+        <div class="bundle-header">BUNDLE & SPARE</div>
+        <form id="bundleForm">
+          ${staffel.map((s, i) => `
+            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
+              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
+              <div class="bundle-info">
+                <div class="bundle-title">
+                  ${s.qty} Set${s.qty>1?'s':''} kaufen
+                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
+                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
+                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
+                </div>
+                <div class="bundle-prices">
+                  €${s.price.toFixed(2)} pro Set
+                  <span class="old">€${s.original.toFixed(2)}</span>
+                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
+                </div>
+                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
+              </div>
+            </div>
+          `).join('')}
+          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
+        </form>
+      </div>
+    `;
+    // Interaktive Auswahl
+    const cards = section.querySelectorAll('.bundle-card');
+    const radios = section.querySelectorAll('.bundle-radio');
+    
+    // Event-Listener für Radio-Buttons
+    radios.forEach((radio, i) => {
+      radio.addEventListener('change', () => {
+        cards.forEach(c => c.classList.remove('selected'));
+        cards[i].classList.add('selected');
+      });
+    });
+
+    // Event-Listener für Bundle-Cards
+    cards.forEach((card, i) => {
+      card.addEventListener('click', (e) => {
+        // Verhindere Bubbling wenn auf Radio geklickt wurde
+        if (e.target === radios[i]) return;
+        
+        // Wähle Radio-Button aus
+        radios[i].checked = true;
+        
+        // Aktualisiere Selected-Status
+        cards.forEach(c => c.classList.remove('selected'));
+        card.classList.add('selected');
+        
+        // Trigger change Event auf Radio
+        radios[i].dispatchEvent(new Event('change'));
+      });
+    });
+
+    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      const idx = Array.from(radios).findIndex(r => r.checked);
+      const s = staffel[idx];
+      addBundleToCart({
+        id: product.id,
+        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
+        price: s.price * s.qty, // Gesamtpreis für das Bundle
+        image: product.image,
+        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
+        bundleId: `${product.id}-qty${s.qty}`,
+        quantity: 1
+      });
+    });
+  }
+
+  function addBundleToCart(bundle) {
+    let cart = getCart();
+    // Bundle als eigenes Cart-Item mit bundleId
+    const bundleId = `${product.id}-${bundle.id}`;
+    const existing = cart.find(item => item.bundleId === bundleId);
+    if (existing) {
+      // Bei Bundles immer nur 1 erlauben
+      existing.quantity = 1;
+    } else {
+      cart.push({
+        id: product.id,
+        name: product.name + ' - ' + bundle.name,
+        price: bundle.price,
+        image: product.image,
+        description: product.description + ' (Bundle: ' + bundle.name + ')',
+        bundleId: bundleId,
+        bundleItems: bundle.items,
+        quantity: 1
+      });
+    }
+    setCart(cart);
+    // Popup anzeigen statt direkter Weiterleitung
+    if (typeof showAlert === 'function') {
+      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
+    } else {
+      showNotification('Bundle zum Warenkorb hinzugefügt');
+    }
+  }
 
   function getWishlist() {
     return JSON.parse(localStorage.getItem('wishlist')) || [];
@@ -325,14 +436,27 @@
     updateWishlistButton();
   }
   function updateWishlistButton() {
-    const btn = document.getElementById('wishlistBtn');
-    if (!btn) return;
+    const heroBtn = document.getElementById('wishlistBtn');
+    const cardBtn = document.getElementById('cardWishlistBtn');
+    
     if (isInWishlist(product.id)) {
-      btn.classList.add('active');
-      btn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
+      if (heroBtn) {
+        heroBtn.classList.add('active');
+        heroBtn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
+      }
+      if (cardBtn) {
+        cardBtn.classList.add('active');
+        cardBtn.innerHTML = '<i class="bi bi-heart-fill"></i> Entfernen';
+      }
     } else {
-      btn.classList.remove('active');
-      btn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste';
+      if (heroBtn) {
+        heroBtn.classList.remove('active');
+        heroBtn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste';
+      }
+      if (cardBtn) {
+        cardBtn.classList.remove('active');
+        cardBtn.innerHTML = '<i class="bi bi-heart"></i> Zur Wunschliste hinzufügen';
+      }
     }
   }
   function getCart() {
@@ -341,16 +465,25 @@
   function setCart(cart) {
             localStorage.setItem('cart', JSON.stringify(cart));
   }
-  function addToCart(product) {
-      let cart = getCart();
-      const existing = cart.find(item => Number(item.id) === Number(product.id));
-      if (existing) {
-          existing.quantity += product.quantity || 1;
-      } else {
-          cart.push({ ...product, quantity: product.quantity || 1 });
-      }
-      setCart(cart);
-      // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
+  function addToCart(productId, quantity = 1) {
+    let cart = getCart();
+    const productData = {
+      id: productId,
+      name: document.querySelector('.product-hero h1').textContent,
+      price: parseFloat(document.querySelector('.price-tag').textContent.replace('€','')),
+      image: document.querySelector('.product-image').src,
+      description: document.querySelector('.product-hero p').textContent,
+      quantity: quantity
+    };
+    
+    const existing = cart.find(item => Number(item.id) === Number(productData.id));
+    if (existing) {
+      existing.quantity += productData.quantity;
+    } else {
+      cart.push(productData);
+    }
+    setCart(cart);
+    // Keine direkte Weiterleitung mehr, da wir das Popup verwenden
   }
   
   // showAlert function for cart popup
@@ -432,212 +565,92 @@
     }, 2000);
   }
 
-  function addBundleToCart(bundle) {
-    let cart = getCart();
-    const bundleId = bundle.bundleId;
-    const existing = cart.find(item => item.bundleId === bundleId);
-    if (existing) {
-        existing.quantity = 1;
-    } else {
-        cart.push({
-            id: product.id,
-            name: bundle.name,
-            price: bundle.price,
-            image: product.image,
-            description: bundle.description,
-            bundleId: bundleId,
-            bundleItems: [], // Keine Items für die neue Staffel
-            quantity: 1
-        });
-    }
-    setCart(cart);
-    // Popup anzeigen statt direkter Weiterleitung
-    if (typeof showAlert === 'function') {
-      showAlert('Bundle zum Warenkorb hinzugefügt', 'cart.html');
-    } else {
-      showNotification('Bundle zum Warenkorb hinzugefügt');
-    }
-}
-
-  function renderBundles() {
-    const einzelpreis = 44.00;
-    const staffel = [
-      {qty:1, price:einzelpreis, original:einzelpreis},
-      {qty:2, price:(einzelpreis*0.85), original:einzelpreis},
-      {qty:3, price:(einzelpreis*0.80), original:einzelpreis}
-    ];
-    const section = document.getElementById('bundle-section');
-    let selected = 1;
-    section.innerHTML = `
-      <div class="bundle-box">
-        <div class="bundle-header">BUNDLE & SPARE</div>
-        <form id="bundleForm">
-          ${staffel.map((s, i) => `
-            <div class="bundle-card${i===selected?' selected':''}" data-index="${i}">
-              <input type="radio" name="bundle" class="bundle-radio" id="bundleRadio${i}" value="${i}" ${i===selected?'checked':''}>
-              <div class="bundle-info">
-                <div class="bundle-title">
-                  ${s.qty} Set${s.qty>1?'s':''} kaufen
-                  ${i===1 ? '<span class="bundle-badge popular">Am beliebtesten</span>' : ''}
-                  ${i===2 ? '<span class="bundle-badge savings">Meiste Ersparnis</span>' : ''}
-                  ${i>0 ? `<span class="bundle-label">EXTRA ${i===1?'15':i===2?'20':'0'}% RABATT</span>` : ''}
-                </div>
-                <div class="bundle-prices">
-                  €${s.price.toFixed(2)} pro Set
-                  <span class="old">€${s.original.toFixed(2)}</span>
-                  <span class="savings">Spare €${((s.original-s.price)*s.qty).toFixed(2)}</span>
-                </div>
-                ${s.qty>1?`<div class='bundle-total'>Gesamt: <b>€${(s.price*s.qty).toFixed(2)}</b> <span class='old'>€${(s.original*s.qty).toFixed(2)}</span></div>`:''}
-              </div>
-            </div>
-          `).join('')}
-          <button type="submit" class="btn bundle-add-btn">In den Warenkorb</button>
-        </form>
-      </div>
-    `;
-    // Interaktive Auswahl
-    const cards = section.querySelectorAll('.bundle-card');
-    const radios = section.querySelectorAll('.bundle-radio');
-    
-    // Event-Listener für Radio-Buttons
-    radios.forEach((radio, i) => {
-      radio.addEventListener('change', () => {
-        cards.forEach(c => c.classList.remove('selected'));
-        cards[i].classList.add('selected');
-      });
-    });
-
-    // Event-Listener für Bundle-Cards
-    cards.forEach((card, i) => {
-      card.addEventListener('click', (e) => {
-        // Verhindere Bubbling wenn auf Radio geklickt wurde
-        if (e.target === radios[i]) return;
-        
-        // Wähle Radio-Button aus
-        radios[i].checked = true;
-        
-        // Aktualisiere Selected-Status
-        cards.forEach(c => c.classList.remove('selected'));
-        card.classList.add('selected');
-        
-        // Trigger change Event auf Radio
-        radios[i].dispatchEvent(new Event('change'));
-      });
-    });
-
-    section.querySelector('#bundleForm').addEventListener('submit', function(e) {
-      e.preventDefault();
-      const idx = Array.from(radios).findIndex(r => r.checked);
-      const s = staffel[idx];
-      addBundleToCart({
-        id: product.id,
-        name: product.name + ` (${s.qty} Set${s.qty>1?'s':''})`,
-        price: s.price * s.qty,
-        image: product.image,
-        description: product.description + ` (Bundle: ${s.qty} Set${s.qty>1?'s':''})`,
-        bundleId: `${product.id}-qty${s.qty}`,
-        quantity: s.qty
-      });
-    });
-  }
-
-  renderBundles();
-
-  // Funktionen für die neue Schnellbestellung
-  function increaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue < 10) {
-        input.value = currentValue + 1;
-        updateTotalPrice();
-      }
+  // Mengenfunktionen für Schnellbestellung
+  function decreaseQuantity() {
+    const quantityInput = document.getElementById('quantity');
+    const currentValue = parseInt(quantityInput.value, 10) || 1;
+    if (currentValue > 1) {
+      quantityInput.value = currentValue - 1;
+      updatePrices();
     }
   }
 
-  function decreaseQuantity(event) {
-    // Determine which quantity input to use based on the clicked button
-    const button = event ? event.target : null;
-    const isDesktop = button && button.closest('.d-none.d-lg-block');
-    
-    const inputId = isDesktop ? 'quantity-desktop' : 'quantity';
-    const input = document.getElementById(inputId);
-    
-    if (input) {
-      const currentValue = parseInt(input.value, 10) || 1;
-      if (currentValue > 1) {
-        input.value = currentValue - 1;
-        updateTotalPrice();
-      }
+  function increaseQuantity() {
+    const quantityInput = document.getElementById('quantity');
+    const currentValue = parseInt(quantityInput.value, 10) || 1;
+    if (currentValue < 10) {
+      quantityInput.value = currentValue + 1;
+      updatePrices();
     }
   }
 
-  function updateTotalPrice() {
-    const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
-    const total = (product.price * quantity).toFixed(2);
-    document.getElementById('totalPrice').textContent = `€${total}`;
+  function updatePrices() {
+    const quantityInput = document.getElementById('quantity');
+    const currentPriceSpan = document.getElementById('currentPrice');
+    const totalPriceSpan = document.getElementById('totalPrice');
+    const buyBtn = document.querySelector('.buy-now-btn');
+    
+    const qty = parseInt(quantityInput.value, 10) || 1;
+    const total = (product.price * qty).toFixed(2);
+    
+    if (currentPriceSpan) currentPriceSpan.textContent = product.price.toFixed(2);
+    if (totalPriceSpan) totalPriceSpan.textContent = total;
+    if (buyBtn) {
+      buyBtn.innerHTML = `<i class="bi bi-cart-plus"></i> Jetzt kaufen - €${total}`;
+    }
   }
-
-
 
   document.addEventListener('DOMContentLoaded', function() {
-    // Event-Listener für Hero-Buttons
-    const cartBtn = document.getElementById('cartBtn');
-    const wishlistBtn = document.getElementById('wishlistBtn');
-    
-    if (cartBtn) {
-      cartBtn.addEventListener('click', function(e) {
+    // Hero Wishlist-Button
+    let heroWishlistBtn = document.getElementById('wishlistBtn');
+    if (heroWishlistBtn) {
+      heroWishlistBtn.addEventListener('click', function(e) {
         e.preventDefault();
-        addToCart({
-            id: product.id,
-            name: product.name,
-            price: product.price,
-            image: product.image,
-            description: product.description,
-            quantity: 1
-        });
+        toggleWishlist(product);
+      });
+    }
+    
+    // Hero Cart-Button
+    let heroCartBtn = document.getElementById('heroCartBtn');
+    if (heroCartBtn) {
+      heroCartBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        const quantity = parseInt(document.getElementById('quantity').value, 10) || 1;
+        addToCart(product.id, quantity);
         // Popup anzeigen statt direkter Weiterleitung
         if (typeof showAlert === 'function') {
           showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');
         } else {
           showNotification('Zum Warenkorb hinzugefügt');
         }
-    });
+      });
     }
     
-    if (wishlistBtn) {
-      wishlistBtn.addEventListener('click', function(e) {
+    // Card Wishlist-Button
+    let cardWishlistBtn = document.getElementById('cardWishlistBtn');
+    if (cardWishlistBtn) {
+      cardWishlistBtn.addEventListener('click', function(e) {
         e.preventDefault();
         toggleWishlist(product);
       });
-      updateWishlistButton();
     }
-
-    // Event-Listener für Quantity-Input
+    
+    // Update both wishlist buttons on page load
+    updateWishlistButton();
+    
+    // Buy Now Button
     const quantityInput = document.getElementById('quantity');
     const buyNowBtn = document.getElementById('buyNowBtn');
     
-    if (quantityInput) {
-      quantityInput.addEventListener('input', updateTotalPrice);
-      quantityInput.addEventListener('change', updateTotalPrice);
-      updateTotalPrice(); // Initialisiere den Preis
-    }
-    
-    if (buyNowBtn) {
+    if (quantityInput && buyNowBtn) {
+      quantityInput.addEventListener('input', updatePrices);
+      quantityInput.addEventListener('change', updatePrices);
+      updatePrices();
+      
       buyNowBtn.addEventListener('click', function(e) {
         e.preventDefault();
-        const quantity = parseInt(quantityInput.value, 10) || 1;
-        const productToCart = {
-          ...product,
-          quantity: quantity
-        };
-        addToCart(productToCart);
+        const qty = parseInt(quantityInput.value, 10) || 1;
+        addToCart(product.id, qty);
         // Popup anzeigen statt direkter Weiterleitung
         if (typeof showAlert === 'function') {
           showAlert('Produkt zum Warenkorb hinzugefügt', 'cart.html');


### PR DESCRIPTION
Fix quick order quantity controls and price updates on all product pages.

The quantity buttons (+/-) and manual input were not updating the quantity or total price correctly for both mobile and desktop versions of the quick order section. This PR extends the functionality to correctly handle both mobile and desktop quantity controls and ensures real-time price updates for both.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3a15291-07fc-4706-9980-d63b8f73e905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3a15291-07fc-4706-9980-d63b8f73e905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

